### PR TITLE
Fixed undefined PyUnicode_AsUTF8() in python < 3.3

### DIFF
--- a/_mysql.c
+++ b/_mysql.c
@@ -44,6 +44,9 @@ PERFORMANCE OF THIS SOFTWARE.
 #define PyInt_Check(n) PyLong_Check(n)
 #define PyInt_AS_LONG(n) PyLong_AS_LONG(n)
 #define PyString_FromString(s) PyUnicode_FromString(s)
+#if (PY_VERSION_HEX < 0x03030000)
+#define PyUnicode_AsUTF8(x) PyBytes_AsString(PyUnicode_AsUTF8String(x))
+#endif
 #endif
 
 #include "bytesobject.h"


### PR DESCRIPTION
PyUnicode_AsUTF8() is available only in Python 3.3 or greater, so it must be defined explicitly in order for the module to work on older python versions (tested with python 3.2 found in Debian Wheezy).