### PR TITLE
missing default value: raise IntegrityError

### DIFF
--- a/_mysql.c
+++ b/_mysql.c
@@ -194,6 +194,9 @@ _mysql_Exception(_mysql_ConnectionObject *c)
 #ifdef ER_CANNOT_ADD_FOREIGN
 	case ER_CANNOT_ADD_FOREIGN:
 #endif
+#ifdef ER_NO_DEFAULT_FOR_FIELD
+	case ER_NO_DEFAULT_FOR_FIELD:
+#endif
 		e = _mysql_IntegrityError;
 		break;
 #ifdef ER_WARNING_NOT_COMPLETE_ROLLBACK


### PR DESCRIPTION
missing default value: raise IntegrityError instead of OperationalError

Follow Python DB API 2.0:
http://legacy.python.org/dev/peps/pep-0249/#integrityerror

Initially reported here:
https://sourceforge.net/p/mysql-python/bugs/336/