### PR TITLE
Fix __gxx_personality_v0: referenced symbol not found error

### DIFF
--- a/setup_posix.py
+++ b/setup_posix.py
@@ -90,6 +90,7 @@ def get_config():
         ]
     create_release_file(metadata)
     del metadata['version_info']
+    libraries.append('stdc++')
     ext_options = dict(
         name = "_mysql",
         library_dirs = library_dirs,


### PR DESCRIPTION
Tested on a Solaris 10 machine, original patch and bug report from
http://sourceforge.net/p/mysql-python/bugs/334/
Closes #35