### PR TITLE
connections.py use int not atoi

### DIFF
--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -325,10 +325,9 @@ class Connection(_mysql.connection):
         def warning_count(self):
             """Return the number of warnings generated from the
             last query. This is derived from the info() method."""
-            from string import atoi
             info = self.info()
             if info:
-                return atoi(info.split()[-1])
+                return int(info.split()[-1])
             else:
                 return 0
 


### PR DESCRIPTION
`atoi` is deprecated since python 2.0 and not in python 3. I guess this code is not being run since `_mysql.c` looks like it always defines `warning_count` anyway, but it should not sit around being python-3-incompatible.