### PR TITLE
Add tests for times module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 build/
 dist/
 MySQLdb/release.py
+.coverage

--- a/MySQLdb/times.py
+++ b/MySQLdb/times.py
@@ -4,7 +4,7 @@ This module provides some Date and Time classes for dealing with MySQL data.
 
 Use Python datetime module to handle date and time columns.
 """
-from time import localtime
+from time import gmtime
 from datetime import date, datetime, time, timedelta
 from _mysql import string_literal
 
@@ -18,15 +18,15 @@ DateTimeType = datetime
 
 def DateFromTicks(ticks):
     """Convert UNIX ticks into a date instance."""
-    return date(*localtime(ticks)[:3])
+    return date(*gmtime(ticks)[:3])
 
 def TimeFromTicks(ticks):
     """Convert UNIX ticks into a time instance."""
-    return time(*localtime(ticks)[3:6])
+    return time(*gmtime(ticks)[3:6])
 
 def TimestampFromTicks(ticks):
     """Convert UNIX ticks into a datetime instance."""
-    return datetime(*localtime(ticks)[:6])
+    return datetime(*gmtime(ticks)[:6])
 
 format_TIME = format_DATE = str
 

--- a/MySQLdb/times.py
+++ b/MySQLdb/times.py
@@ -64,7 +64,7 @@ def DateTime_or_None(s):
             ms = 0
         return datetime(*[ int(x) for x in d.split('-')+t.split(':')+[ms] ])
     except (SystemExit, KeyboardInterrupt):
-        raise
+        raise  # pragma: no cover
     except:
         return Date_or_None(s)
 
@@ -129,6 +129,6 @@ def mysql_timestamp_converter(s):
     try:
         return Timestamp(*parts)
     except (SystemExit, KeyboardInterrupt):
-        raise
+        raise  # pragma: no cover
     except:
         return None

--- a/MySQLdb/times.py
+++ b/MySQLdb/times.py
@@ -4,7 +4,7 @@ This module provides some Date and Time classes for dealing with MySQL data.
 
 Use Python datetime module to handle date and time columns.
 """
-from time import gmtime
+from time import localtime
 from datetime import date, datetime, time, timedelta
 from _mysql import string_literal
 
@@ -18,15 +18,15 @@ DateTimeType = datetime
 
 def DateFromTicks(ticks):
     """Convert UNIX ticks into a date instance."""
-    return date(*gmtime(ticks)[:3])
+    return date(*localtime(ticks)[:3])
 
 def TimeFromTicks(ticks):
     """Convert UNIX ticks into a time instance."""
-    return time(*gmtime(ticks)[3:6])
+    return time(*localtime(ticks)[3:6])
 
 def TimestampFromTicks(ticks):
     """Convert UNIX ticks into a datetime instance."""
-    return datetime(*gmtime(ticks)[:6])
+    return datetime(*localtime(ticks)[:6])
 
 format_TIME = format_DATE = str
 

--- a/tests/test_MySQLdb_times.py
+++ b/tests/test_MySQLdb_times.py
@@ -1,4 +1,6 @@
+import mock
 import unittest
+from time import gmtime
 from datetime import time, date, datetime, timedelta
 
 from MySQLdb import times
@@ -59,16 +61,19 @@ class TestX_or_None(unittest.TestCase):
 
 
 class TestTicks(unittest.TestCase):
-    def test_date_from_ticks(self):
+    @mock.patch('MySQLdb.times.localtime', side_effect=gmtime)
+    def test_date_from_ticks(self, mock):
         assert times.DateFromTicks(0) == date(1970, 1, 1)
         assert times.DateFromTicks(1430000000) == date(2015, 4, 25)
 
-    def test_time_from_ticks(self):
+    @mock.patch('MySQLdb.times.localtime', side_effect=gmtime)
+    def test_time_from_ticks(self, mock):
         assert times.TimeFromTicks(0) == time(0, 0, 0)
         assert times.TimeFromTicks(1431100000) == time(15, 46, 40)
         assert times.TimeFromTicks(1431100000.123) == time(15, 46, 40)
 
-    def test_timestamp_from_ticks(self):
+    @mock.patch('MySQLdb.times.localtime', side_effect=gmtime)
+    def test_timestamp_from_ticks(self, mock):
         assert times.TimestampFromTicks(0) == datetime(1970, 1, 1, 0, 0, 0)
         assert times.TimestampFromTicks(1430000000) == datetime(2015, 4, 25, 22, 13, 20)
         assert times.TimestampFromTicks(1430000000.123) == datetime(2015, 4, 25, 22, 13, 20)

--- a/tests/test_MySQLdb_times.py
+++ b/tests/test_MySQLdb_times.py
@@ -93,7 +93,6 @@ class TestToLiteral(unittest.TestCase):
 
     def test_datetimedelta_to_literal(self):
         d = datetime(2015, 12, 13, 1, 2, 3) - datetime(2015, 12, 13, 1, 2, 2)
-        print(times.DateTimeDelta2literal(d, ''))
         assert times.DateTimeDelta2literal(d, '') == b"'0 0:0:1'"
 
 

--- a/tests/test_MySQLdb_times.py
+++ b/tests/test_MySQLdb_times.py
@@ -46,6 +46,7 @@ class TestX_or_None(unittest.TestCase):
         assert times.DateTime_or_None('2015-12-13T01:02:03.123456789') is None
 
     def test_timedelta_or_none(self):
+        assert times.TimeDelta_or_None('-1:0:0') == timedelta(0, -3600)
         assert times.TimeDelta_or_None('1:0:0') == timedelta(0, 3600)
         assert times.TimeDelta_or_None('12:55:30') == timedelta(0, 46530)
         assert times.TimeDelta_or_None('12:55:30.123456') == timedelta(0, 46530, 123456)

--- a/tests/test_MySQLdb_times.py
+++ b/tests/test_MySQLdb_times.py
@@ -1,0 +1,114 @@
+import unittest
+from datetime import time, date, datetime, timedelta
+
+from MySQLdb import times
+
+import warnings
+warnings.simplefilter("ignore")
+
+
+class TestX_or_None(unittest.TestCase):
+    def test_date_or_none(self):
+        assert times.Date_or_None('1969-1-1') == date(1969, 1, 1)
+        assert times.Date_or_None('2015-1-1') == date(2015, 1, 1)
+        assert times.Date_or_None('2015-12-13') == date(2015, 12, 13)
+
+        assert times.Date_or_None('') is None
+        assert times.Date_or_None('fail') is None
+        assert times.Date_or_None('2015-12') is None
+        assert times.Date_or_None('2015-12-40') is None
+        assert times.Date_or_None('15-12-13').year != 2015
+
+    def test_time_or_none(self):
+        assert times.Time_or_None('00:00:00') == time(0, 0)
+        assert times.Time_or_None('01:02:03') == time(1, 2, 3)
+        assert times.Time_or_None('01:02:03.123456') == time(1, 2, 3, 123456)
+
+        assert times.Time_or_None('') is None
+        assert times.Time_or_None('fail') is None
+        assert times.Time_or_None('24:00:00') is None
+        assert times.Time_or_None('01:02:03.123456789') is None
+
+    def test_datetime_or_none(self):
+        assert times.DateTime_or_None('15-12-13') == date(15, 12, 13)
+        assert times.DateTime_or_None('2015-12-13') == date(2015, 12, 13)
+        assert times.DateTime_or_None('2015-12-13 01:02') == datetime(2015, 12, 13, 1, 2)
+        assert times.DateTime_or_None('2015-12-13T01:02') == datetime(2015, 12, 13, 1, 2)
+        assert times.DateTime_or_None('2015-12-13 01:02:03') == datetime(2015, 12, 13, 1, 2, 3)
+        assert times.DateTime_or_None('2015-12-13T01:02:03') == datetime(2015, 12, 13, 1, 2, 3)
+        assert times.DateTime_or_None('2015-12-13 01:02:03.123') == datetime(2015, 12, 13, 1, 2, 3, 123000)
+        assert times.DateTime_or_None('2015-12-13 01:02:03.000123') == datetime(2015, 12, 13, 1, 2, 3, 123)
+        assert times.DateTime_or_None('2015-12-13 01:02:03.123456') == datetime(2015, 12, 13, 1, 2, 3, 123456)
+        assert times.DateTime_or_None('2015-12-13T01:02:03.123456') == datetime(2015, 12, 13, 1, 2, 3, 123456)
+
+        assert times.DateTime_or_None('') is None
+        assert times.DateTime_or_None('fail') is None
+        assert times.DateTime_or_None('2015-12-13T01:02:03.123456789') is None
+
+    def test_timedelta_or_none(self):
+        assert times.TimeDelta_or_None('1:0:0') == timedelta(0, 3600)
+        assert times.TimeDelta_or_None('12:55:30') == timedelta(0, 46530)
+        assert times.TimeDelta_or_None('12:55:30.123456') == timedelta(0, 46530, 123456)
+        assert times.TimeDelta_or_None('12:55:30.123456789') == timedelta(0, 46653, 456789)
+        assert times.TimeDelta_or_None('12:55:30.123456789123456') == timedelta(1429, 37719, 123456)
+
+        assert times.TimeDelta_or_None('') is None
+        assert times.TimeDelta_or_None('0') is None
+        assert times.TimeDelta_or_None('fail') is None
+
+
+class TestTicks(unittest.TestCase):
+    def test_date_from_ticks(self):
+        assert times.DateFromTicks(0) == date(1970, 1, 1)
+        assert times.DateFromTicks(1430000000) == date(2015, 4, 26)
+
+    def test_time_from_ticks(self):
+        assert times.TimeFromTicks(0) == time(1, 0, 0)
+        assert times.TimeFromTicks(1431100000) == time(17, 46, 40)
+        assert times.TimeFromTicks(1431100000.123) == time(17, 46, 40)
+
+    def test_timestamp_from_ticks(self):
+        assert times.TimestampFromTicks(0) == datetime(1970, 1, 1, 1, 0, 0)
+        assert times.TimestampFromTicks(1430000000) == datetime(2015, 4, 26, 0, 13, 20)
+        assert times.TimestampFromTicks(1430000000.123) == datetime(2015, 4, 26, 0, 13, 20)
+
+
+class TestTimestampConverter(unittest.TestCase):
+    def test_mysql_timestamp_converter(self):
+        assert times.mysql_timestamp_converter('2015-12-13') == date(2015, 12, 13)
+        assert times.mysql_timestamp_converter('2038-01-19 03:14:07') == datetime(2038, 1, 19, 3, 14, 7)
+
+        assert times.mysql_timestamp_converter('2015121310') == datetime(2015, 12, 13, 10, 0)
+        assert times.mysql_timestamp_converter('20151213101112') == datetime(2015, 12, 13, 10, 11, 12)
+
+        assert times.mysql_timestamp_converter('20151313') is None
+        assert times.mysql_timestamp_converter('2015-13-13') is None
+
+
+class TestToLiteral(unittest.TestCase):
+    def test_datetime_to_literal(self):
+        assert times.DateTime2literal(datetime(2015, 12, 13), '') == b"'2015-12-13 00:00:00'"
+        assert times.DateTime2literal(datetime(2015, 12, 13, 11, 12, 13), '') == b"'2015-12-13 11:12:13'"
+        assert times.DateTime2literal(datetime(2015, 12, 13, 11, 12, 13, 123456), '') == b"'2015-12-13 11:12:13.123456'"
+
+    def test_datetimedelta_to_literal(self):
+        d = datetime(2015, 12, 13, 1, 2, 3) - datetime(2015, 12, 13, 1, 2, 2)
+        print(times.DateTimeDelta2literal(d, ''))
+        assert times.DateTimeDelta2literal(d, '') == b"'0 0:0:1'"
+
+
+class TestFormat(unittest.TestCase):
+    def test_format_timedelta(self):
+        d = datetime(2015, 1, 1) - datetime(2015, 1, 1)
+        assert times.format_TIMEDELTA(d) == '0 0:0:0'
+
+        d = datetime(2015, 1, 1, 10, 11, 12) - datetime(2015, 1, 1, 8, 9, 10)
+        assert times.format_TIMEDELTA(d) == '0 2:2:2'
+
+        d = datetime(2015, 1, 1, 10, 11, 12) - datetime(2015, 1, 1, 11, 12, 13)
+        assert times.format_TIMEDELTA(d) == '-1 22:58:59'
+
+    def test_format_timestamp(self):
+        assert times.format_TIMESTAMP(datetime(2015, 2, 3)) == '2015-02-03 00:00:00'
+        assert times.format_TIMESTAMP(datetime(2015, 2, 3, 17, 18, 19)) == '2015-02-03 17:18:19'
+        assert times.format_TIMESTAMP(datetime(15, 2, 3, 17, 18, 19)) == '0015-02-03 17:18:19'

--- a/tests/test_MySQLdb_times.py
+++ b/tests/test_MySQLdb_times.py
@@ -60,17 +60,17 @@ class TestX_or_None(unittest.TestCase):
 class TestTicks(unittest.TestCase):
     def test_date_from_ticks(self):
         assert times.DateFromTicks(0) == date(1970, 1, 1)
-        assert times.DateFromTicks(1430000000) == date(2015, 4, 26)
+        assert times.DateFromTicks(1430000000) == date(2015, 4, 25)
 
     def test_time_from_ticks(self):
-        assert times.TimeFromTicks(0) == time(1, 0, 0)
-        assert times.TimeFromTicks(1431100000) == time(17, 46, 40)
-        assert times.TimeFromTicks(1431100000.123) == time(17, 46, 40)
+        assert times.TimeFromTicks(0) == time(0, 0, 0)
+        assert times.TimeFromTicks(1431100000) == time(15, 46, 40)
+        assert times.TimeFromTicks(1431100000.123) == time(15, 46, 40)
 
     def test_timestamp_from_ticks(self):
-        assert times.TimestampFromTicks(0) == datetime(1970, 1, 1, 1, 0, 0)
-        assert times.TimestampFromTicks(1430000000) == datetime(2015, 4, 26, 0, 13, 20)
-        assert times.TimestampFromTicks(1430000000.123) == datetime(2015, 4, 26, 0, 13, 20)
+        assert times.TimestampFromTicks(0) == datetime(1970, 1, 1, 0, 0, 0)
+        assert times.TimestampFromTicks(1430000000) == datetime(2015, 4, 25, 22, 13, 20)
+        assert times.TimestampFromTicks(1430000000.123) == datetime(2015, 4, 25, 22, 13, 20)
 
 
 class TestTimestampConverter(unittest.TestCase):

--- a/tests/test_MySQLdb_times.py
+++ b/tests/test_MySQLdb_times.py
@@ -11,15 +11,14 @@ warnings.simplefilter("ignore")
 
 class TestX_or_None(unittest.TestCase):
     def test_date_or_none(self):
-        assert times.Date_or_None('1969-1-1') == date(1969, 1, 1)
-        assert times.Date_or_None('2015-1-1') == date(2015, 1, 1)
+        assert times.Date_or_None('1969-01-01') == date(1969, 1, 1)
+        assert times.Date_or_None('2015-01-01') == date(2015, 1, 1)
         assert times.Date_or_None('2015-12-13') == date(2015, 12, 13)
 
         assert times.Date_or_None('') is None
         assert times.Date_or_None('fail') is None
         assert times.Date_or_None('2015-12') is None
         assert times.Date_or_None('2015-12-40') is None
-        assert times.Date_or_None('15-12-13').year != 2015
 
     def test_time_or_none(self):
         assert times.Time_or_None('00:00:00') == time(0, 0)
@@ -32,7 +31,7 @@ class TestX_or_None(unittest.TestCase):
         assert times.Time_or_None('01:02:03.123456789') is None
 
     def test_datetime_or_none(self):
-        assert times.DateTime_or_None('15-12-13') == date(15, 12, 13)
+        assert times.DateTime_or_None('1000-01-01') == date(1000, 1, 1)
         assert times.DateTime_or_None('2015-12-13') == date(2015, 12, 13)
         assert times.DateTime_or_None('2015-12-13 01:02') == datetime(2015, 12, 13, 1, 2)
         assert times.DateTime_or_None('2015-12-13T01:02') == datetime(2015, 12, 13, 1, 2)

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py26, py27, pypy, py33, py34
 commands =
     py.test --cov {envsitepackagesdir}/MySQLdb
 deps =
+    mock
     coverage==3.7.1
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,5 @@
 envlist = py26, py27, pypy, py33, py34
 
 [testenv]
-commands =
-    nosetests {posargs:-w tests -v}
-deps =
-    nose
+commands = py.test
+deps = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,9 @@
 envlist = py26, py27, pypy, py33, py34
 
 [testenv]
-commands = py.test
-deps = pytest
+commands =
+    py.test --cov {envsitepackagesdir}/MySQLdb
+deps =
+    coverage==3.7.1
+    pytest
+    pytest-cov


### PR DESCRIPTION
This adds close to 100% coverage for `MySQLdb.times`. We're experience a lot of our request time spent in this module and this is the first step of trying to optimize its performance.