### PR TITLE
Increase performance when casting dates

### DIFF
--- a/MySQLdb/times.py
+++ b/MySQLdb/times.py
@@ -51,28 +51,28 @@ def DateTime_or_None(s):
     try:
         if len(s) < 11:
             return Date_or_None(s)
+
+        micros = s[20:]
+
+        if len(micros) == 0:
+            # 12:00:00
+            micros = 0
+        elif len(micros) < 7:
+            # 12:00:00.123456
+            micros = int(micros) * 10 ** (6 - len(micros))
         else:
-            micros = s[20:]
+            # 12:00:00.123456789
+            micros = int(micros)
 
-            if len(micros) == 0:
-                # 12:00:00
-                micros = 0
-            elif len(micros) < 7:
-                # 12:00:00.123456
-                micros = int(micros) * 10 ** (6 - len(micros))
-            else:
-                # 12:00:00.123456789
-                micros = int(micros)
-
-            return datetime(
-                int(s[:4]),          # year
-                int(s[5:7]),         # month
-                int(s[8:10]),        # day
-                int(s[11:13] or 0),  # hour
-                int(s[14:16] or 0),  # minute
-                int(s[17:19] or 0),  # second
-                micros,              # microsecond
-            )
+        return datetime(
+            int(s[:4]),          # year
+            int(s[5:7]),         # month
+            int(s[8:10]),        # day
+            int(s[11:13] or 0),  # hour
+            int(s[14:16] or 0),  # minute
+            int(s[17:19] or 0),  # second
+            micros,              # microsecond
+        )
     except ValueError:
         return None
 

--- a/MySQLdb/times.py
+++ b/MySQLdb/times.py
@@ -61,8 +61,7 @@ def DateTime_or_None(s):
             # 12:00:00.123456
             micros = int(micros) * 10 ** (6 - len(micros))
         else:
-            # 12:00:00.123456789
-            micros = int(micros)
+            return None
 
         return datetime(
             int(s[:4]),          # year

--- a/MySQLdb/times.py
+++ b/MySQLdb/times.py
@@ -57,7 +57,7 @@ def DateTime_or_None(s):
             if len(micros) == 0:
                 # 12:00:00
                 micros = 0
-            elif len(micros) > 0 and len(micros) < 7:
+            elif len(micros) < 7:
                 # 12:00:00.123456
                 micros = int(micros) * 10 ** (6 - len(micros))
             else:

--- a/tests/test_MySQLdb_times.py
+++ b/tests/test_MySQLdb_times.py
@@ -19,6 +19,7 @@ class TestX_or_None(unittest.TestCase):
         assert times.Date_or_None('fail') is None
         assert times.Date_or_None('2015-12') is None
         assert times.Date_or_None('2015-12-40') is None
+        assert times.Date_or_None('0000-00-00') is None
 
     def test_time_or_none(self):
         assert times.Time_or_None('00:00:00') == time(0, 0)
@@ -44,6 +45,8 @@ class TestX_or_None(unittest.TestCase):
 
         assert times.DateTime_or_None('') is None
         assert times.DateTime_or_None('fail') is None
+        assert times.DateTime_or_None('0000-00-00 00:00:00') is None
+        assert times.DateTime_or_None('0000-00-00 00:00:00.000000') is None
         assert times.DateTime_or_None('2015-12-13T01:02:03.123456789') is None
 
     def test_timedelta_or_none(self):


### PR DESCRIPTION
Results from best of three runs with 1 million calls:

```python
OLD '2038-01-19': 3.150
NEW '2038-01-19': 2.509

OLD '2038-01-19 12:13:14': 6.807
NEW '2038-01-19 12:13:14': 4.613

OLD '2038-01-19 12:13:14.123': 7.943
NEW '2038-01-19 12:13:14.123': 5.314
```

This is probably as fast as we can go without turning this into a C extension. Slowest part seems to be casting to `int` right now.