### PR TITLE
Added test for MULTIPOLYGON (that fails in 1742946)

### DIFF
--- a/_mysql.c
+++ b/_mysql.c
@@ -1373,6 +1373,7 @@ _mysql_field_to_python(
 		field_type == FIELD_TYPE_BLOB ||
 		field_type == FIELD_TYPE_VAR_STRING ||
 		field_type == FIELD_TYPE_STRING ||
+		field_type == FIELD_TYPE_GEOMETRY ||
 		field_type == FIELD_TYPE_BIT) {
 			binary = 1;
 	}

--- a/tests/test_MySQLdb_capabilities.py
+++ b/tests/test_MySQLdb_capabilities.py
@@ -116,12 +116,12 @@ class test_MySQLdb(capabilities.DatabaseTest):
             c.execute("SELECT id, AsWKB(border) FROM test_MULTIPOLYGON")
             row = c.fetchone()
             self.assertEqual(row[0], 1)
-            self.assertGreater(len(row[1]), 0)
+            self.assertNotEqual(len(row[1]), 0)
 
             c.execute("SELECT id, border FROM test_MULTIPOLYGON")
             row = c.fetchone()
             self.assertEqual(row[0], 1)
-            self.assertGreater(len(row[1]), 0)
+            self.assertNotEqual(len(row[1]), 0)
         finally:
             c.execute("drop table if exists test_MULTIPOLYGON")
 

--- a/tests/test_MySQLdb_capabilities.py
+++ b/tests/test_MySQLdb_capabilities.py
@@ -96,6 +96,35 @@ class test_MySQLdb(capabilities.DatabaseTest):
         finally:
             c.execute("drop table if exists test_BIT")
 
+    def test_MULTIPOLYGON(self):
+        c = self.cursor
+        try:
+            c.execute("""create table test_MULTIPOLYGON (
+                id INTEGER PRIMARY KEY,
+                border MULTIPOLYGON)""")
+
+            c.execute(
+                "insert into test_MULTIPOLYGON (id, border)"
+                " VALUES (1, GeomFromText('MULTIPOLYGON(((1 1, 1 -1, -1 -1, -1 1, 1 1)),((1 1, 3 1, 3 3, 1 3, 1 1)))'))"
+            )
+
+            c.execute("SELECT id, AsText(border) FROM test_MULTIPOLYGON")
+            row = c.fetchone()
+            self.assertEqual(row[0], 1)
+            self.assertEqual(row[1], b'MULTIPOLYGON(((1 1,1 -1,-1 -1,-1 1,1 1)),((1 1,3 1,3 3,1 3,1 1)))')
+
+            c.execute("SELECT id, AsWKB(border) FROM test_MULTIPOLYGON")
+            row = c.fetchone()
+            self.assertEqual(row[0], 1)
+            self.assertGreater(len(row[1]), 0)
+
+            c.execute("SELECT id, border FROM test_MULTIPOLYGON")
+            row = c.fetchone()
+            self.assertEqual(row[0], 1)
+            self.assertGreater(len(row[1]), 0)
+        finally:
+            c.execute("drop table if exists test_MULTIPOLYGON")
+
     def test_bug_2671682(self):
         from MySQLdb.constants import ER
         try:


### PR DESCRIPTION
Thanks for mysqlclient. :-) When working with Django 1.8 (Python 3.4) with a legacy database containing spatial fields in MySQL 5.5, I got an UnicodeDecodeError as soon as trying to access (read) something from tables containing spatial fields. When tracking down the problem I found that the exception was raised in the mysqlclient module. So I added a small test case and voila - same exception here.

So either I (or Django) are not using your module correctly, or there is a bug.

In case you want me to look closer at the problem I'm willing to do so - however, I think you know your code better than I do and would be much faster when finding out what's going on.