### PR TITLE
Add documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,8 @@ in your `requirements.txt` to avoid trying install source newest pacakge.
 1. Download source by `git clone` or [zipfile](https://github.com/PyMySQL/mysqlclient-python/archive/master.zip).
 2. Customize `site.cfg`
 3. `python setup.py install`
+
+### Documentation
+
+Documentation is hosted on [Read The Docs](https://mysqlclient.readthedocs.org/)
+


### PR DESCRIPTION
Because I couldn't find rendered documentation, I've hosted the docs on https://mysqlclient.readthedocs.org/ and added you as a maintainer