### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ in your `requirements.txt` to avoid trying to install newest source package.
 
 ### Documentation
 
-Documentation is hosted on [Read The Docs](https://mysqlclient.readthedocs.org/)
+Documentation is hosted on [Read The Docs](https://mysqlclient.readthedocs.io/)
 


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.