### PR TITLE
unicode string in argument of string raises error

### DIFF
--- a/MySQLdb/cursors.py
+++ b/MySQLdb/cursors.py
@@ -358,7 +358,7 @@ class BaseCursor(object):
                              ','.join(['@_%s_%d' % (procname, i)
                                        for i in range(len(args))]))
         if isinstance(q, unicode):
-            q = q.encode(db.unicode_literal.charset)
+            q = q.encode(db.unicode_literal.charset, 'surrogateescape')
         self._query(q)
         self._executed = q
         if not self._defer_warnings:


### PR DESCRIPTION
Hi, I've got  'surrogates not allowed' error when I put unicode string into stored procedure's argument.
This is pr for the issue.

cf: https://github.com/PyMySQL/mysqlclient-python/issues/90 .