### PR TITLE
fixed building _mysql.so when static-linking to libmysqlclient(.a)

### DIFF
--- a/setup_posix.py
+++ b/setup_posix.py
@@ -36,6 +36,11 @@ def get_config():
         mysql_config.path = options['mysql_config']
 
     extra_objects = []
+    # the following flag forces an error if any symbols are left undefined
+    if sys.platform == 'darwin':
+        extra_objects.append('-Wl,-undefined,error')
+    else:
+        extra_objects.append('-Wl,--no-undefined')
     static = enabled(options, 'static')
     if enabled(options, 'embedded'):
         libs = mysql_config("libmysqld-libs")
@@ -67,6 +72,8 @@ def get_config():
                     for i in mysql_config('include') if i.startswith('-I')]
 
     if static:
+        # the mysql client lib uses c++, so add a (dynamic) link
+        libraries.append('stdc++')
         extra_objects.append(os.path.join(library_dirs[0], 'lib%s.a' % client))
         if client in libraries:
             libraries.remove(client)


### PR DESCRIPTION
libmysqlclient uses C++, so when linking against the static version of the library,
have to explicitly link against libstdc++. This is a dynamic link because statically linking
against libstdc / libstdc++ is generally a very bad idea, since they can have ties to the kernel.

added a flag to this build process to fail if there are undefined symbols while building.
with this flag, commenting out the addition of 'stdc++' as a library demonstrates the problem (when changing `static` to `True` in `site.cfg`).

side note: also had to change `threadsafe` to `False` when setting `static = True`, since modern / latest libmysqlclient libs:
a) are threadsafe by nature
b) only provide `_r` variants as symlinks to "normal" libs
c) appear to only drop said symlinks against dynamic (`.so`) libs
I didn't touch this logic but could consider refactoring this somehow.