### PR TITLE
Warning propagation improvements

### DIFF
--- a/tests/test_MySQLdb_capabilities.py
+++ b/tests/test_MySQLdb_capabilities.py
@@ -3,6 +3,8 @@ import capabilities
 from datetime import timedelta
 import unittest
 import MySQLdb
+from MySQLdb.compat import unicode
+from MySQLdb import cursors
 import warnings
 
 
@@ -154,6 +156,28 @@ class test_MySQLdb(capabilities.DatabaseTest):
             self.assertEqual(e.args[0], 1146)
             return
         self.fail("Should raise ProgrammingError")
+
+    def test_warning_propagation(self):
+        with warnings.catch_warnings():
+            # Ignore all warnings other than MySQLdb generated ones
+            warnings.simplefilter("ignore")
+            warnings.simplefilter("error", category=MySQLdb.Warning)
+
+            # verify for both buffered and unbuffered cursor types
+            for cursor_class in (cursors.Cursor, cursors.SSCursor):
+                c = self.connection.cursor(cursor_class)
+                try:
+                    c.execute("SELECT CAST('124b' AS SIGNED)")
+                    c.fetchall()
+                except MySQLdb.Warning as e:
+                    # Warnings should have errorcode and string message, just like exceptions
+                    self.assertEqual(len(e.args), 2)
+                    self.assertEqual(e.args[0], 1292)
+                    self.assertTrue(isinstance(e.args[1], unicode))
+                else:
+                    self.fail("Should raise Warning")
+                finally:
+                    c.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Dear MySQLdb team,

Here are a couple of suggestions regarding warnings issued by the library:

1. _Include error code in warnings, not just string_  
I thought it would make sense for the `Warning` instances to not just have a string argument but, same as with errors, to also include the error code (as first argument, with string being second).
2. _Fix warning propagation for unbuffered queries_  
`db.warning_count()` was called during `nextset()`. However, for unbuffered queries, the warning count is not available until the whole result has been fetched. By instead calling `db.warning_count()` later via `_warning_check` instead (which work as `_defer_warnings` is set), warnings are always received.