### PR TITLE
Use _binary prefix for bytes/bytearray parameters

### DIFF
--- a/MySQLdb/__init__.py
+++ b/MySQLdb/__init__.py
@@ -27,6 +27,7 @@ apilevel = "2.0"
 paramstyle = "format"
 
 from _mysql import *
+from MySQLdb.compat import PY2
 from MySQLdb.constants import FIELD_TYPE
 from MySQLdb.times import Date, Time, Timestamp, \
     DateFromTicks, TimeFromTicks, TimestampFromTicks
@@ -72,8 +73,12 @@ def test_DBAPISet_set_equality_membership():
 def test_DBAPISet_set_inequality_membership():
     assert FIELD_TYPE.DATE != STRING
 
-def Binary(x):
-    return bytes(x)
+if PY2:
+    def Binary(x):
+        return bytearray(x)
+else:
+    def Binary(x):
+        return bytes(x)
 
 def Connect(*args, **kwargs):
     """Factory function for connections.Connection."""


### PR DESCRIPTION
[PyMySQL](https://github.com/PyMySQL/PyMySQL) already does this via `escape_bytes()` [converters.py](https://github.com/PyMySQL/PyMySQL/blob/master/pymysql/converters.py). For compatibility maybe this is a good idea? (I think this would behave the same as with PyMySQL in that nothing it only affects bytes~~/bytearray~~ + Python 3 and bytearray for both versions.)

I think it's not possible to add to `Connection.encoders` (via constructor) because e.g. `self.encoders[bytes]` is overridden **after** the `conv` argument is parsed.