### PR TITLE
MySQL Connector/C 6.1.6 doesn't have mysql_real_escape_string_quote

### DIFF
--- a/_mysql.c
+++ b/_mysql.c
@@ -1064,7 +1064,7 @@ _mysql_escape_string(
 	if (self && PyModule_Check((PyObject*)self))
 		self = NULL;
 	if (self && self->open) {
-#if MYSQL_VERSION_ID >= 50706
+#if MYSQL_VERSION_ID >= 50707
 		len = mysql_real_escape_string_quote(&(self->connection), out, in, size, '\'');
 #else
 		len = mysql_real_escape_string(&(self->connection), out, in, size);
@@ -1122,7 +1122,7 @@ _mysql_string_literal(
 	out = PyBytes_AS_STRING(str);
 	check_server_init(NULL);
 	if (self && self->open) {
-#if MYSQL_VERSION_ID >= 50706
+#if MYSQL_VERSION_ID >= 50707
 		len = mysql_real_escape_string_quote(&(self->connection), out+1, in, size, '\'');
 #else
 		len = mysql_real_escape_string(&(self->connection), out+1, in, size);


### PR DESCRIPTION
While it's MYSQL_VERSION_ID is 50706 and MySQL 5.7.6 has it.
Since MySQL 5.7.6 is old milestone version, just drop supporting it.

fixes #110