### PR TITLE
Fix msvc compile error

### DIFF
--- a/_mysql.c
+++ b/_mysql.c
@@ -521,7 +521,7 @@ _mysql_ConnectionObject_Initialize(
 #if HAVE_OPENSSL
 	char *key = NULL, *cert = NULL, *ca = NULL,
 		 *capath = NULL, *cipher = NULL;
-	PyObject *ssl_keepref[5] = {};
+	PyObject *ssl_keepref[5] = {NULL, NULL, NULL, NULL, NULL};
 	int n_ssl_keepref = 0;
 #endif
 	char *host = NULL, *user = NULL, *passwd = NULL,


### PR DESCRIPTION
Building mysqlclient-python-1.3.8 on Windows using msvc9|10|14 fails with `_mysql.c(524): error C2059: syntax error: '}'`.