### PR TITLE
Revert "Use _binary prefix for bytes/bytearray parameters" (#106)

### DIFF
--- a/MySQLdb/__init__.py
+++ b/MySQLdb/__init__.py
@@ -27,7 +27,6 @@ apilevel = "2.0"
 paramstyle = "format"
 
 from _mysql import *
-from MySQLdb.compat import PY2
 from MySQLdb.constants import FIELD_TYPE
 from MySQLdb.times import Date, Time, Timestamp, \
     DateFromTicks, TimeFromTicks, TimestampFromTicks
@@ -73,12 +72,8 @@ def test_DBAPISet_set_equality_membership():
 def test_DBAPISet_set_inequality_membership():
     assert FIELD_TYPE.DATE != STRING
 
-if PY2:
-    def Binary(x):
-        return bytearray(x)
-else:
-    def Binary(x):
-        return bytes(x)
+def Binary(x):
+    return bytes(x)
 
 def Connect(*args, **kwargs):
     """Factory function for connections.Connection."""

--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -197,7 +197,7 @@ class Connection(_mysql.connection):
 
         db = proxy(self)
         def _get_string_literal():
-            # Note: string_literal() is called for bytes object on Python 3 (via bytes_literal)
+            # Note: string_literal() is called for bytes object on Python 3.
             def string_literal(obj, dummy=None):
                 return db.string_literal(obj)
             return string_literal
@@ -213,11 +213,6 @@ class Connection(_mysql.connection):
                     return db.literal(str(u).encode(unicode_literal.charset))
             return unicode_literal
 
-        def _get_bytes_literal():
-            def bytes_literal(obj, dummy=None):
-                return b'_binary' + db.string_literal(obj)
-            return bytes_literal
-
         def _get_string_decoder():
             def string_decoder(s):
                 return s.decode(string_decoder.charset)
@@ -225,7 +220,6 @@ class Connection(_mysql.connection):
 
         string_literal = _get_string_literal()
         self.unicode_literal = unicode_literal = _get_unicode_literal()
-        bytes_literal = _get_bytes_literal()
         self.string_decoder = string_decoder = _get_string_decoder()
         if not charset:
             charset = self.character_set_name()
@@ -240,8 +234,7 @@ class Connection(_mysql.connection):
             self.converter[FIELD_TYPE.VARCHAR].append((None, string_decoder))
             self.converter[FIELD_TYPE.BLOB].append((None, string_decoder))
 
-        self.encoders[bytes] = string_literal if PY2 else bytes_literal
-        self.encoders[bytearray] = bytes_literal
+        self.encoders[bytes] = string_literal
         self.encoders[unicode] = unicode_literal
         self._transactional = self.server_capabilities & CLIENT.TRANSACTIONS
         if self._transactional:


### PR DESCRIPTION
Reverts PyMySQL/mysqlclient-python#106