### PR TITLE
Support for secure_auth mysql option

### DIFF
--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -132,6 +132,11 @@ class Connection(_mysql.connection):
         :param bool local_infile:
             enables LOAD LOCAL INFILE; zero disables
 
+        :param bool secure_auth:
+            If False, secure_auth is disabled.
+            If True, secure_auth is enabled.
+            If None, secure_auth isn't set and server default is used.
+
         :param bool autocommit:
             If False (default), autocommit is disabled.
             If True, autocommit is enabled.

--- a/_mysql.c
+++ b/_mysql.c
@@ -535,6 +535,7 @@ _mysql_ConnectionObject_Initialize(
 				  "read_default_file", "read_default_group",
 				  "client_flag", "ssl",
 				  "local_infile",
+				  "secure_auth",
 #ifdef HAVE_MYSQL_OPT_TIMEOUTS
 				  "read_timeout",
 				  "write_timeout",
@@ -545,7 +546,7 @@ _mysql_ConnectionObject_Initialize(
 	int read_timeout = 0;
 	int write_timeout = 0;
 #endif
-	int compress = -1, named_pipe = -1, local_infile = -1;
+	int compress = -1, named_pipe = -1, local_infile = -1, secure_auth = -1;
 	char *init_command=NULL,
 	     *read_default_file=NULL,
 	     *read_default_group=NULL;
@@ -553,6 +554,8 @@ _mysql_ConnectionObject_Initialize(
 	self->converter = NULL;
 	self->open = 0;
 	check_server_init(-1);
+
+	my_bool opt_secure_auth = -1;
 
 	if (!PyArg_ParseTupleAndKeywords(args, kwargs,
 #ifdef HAVE_MYSQL_OPT_TIMEOUTS
@@ -568,7 +571,8 @@ _mysql_ConnectionObject_Initialize(
 					 &init_command, &read_default_file,
 					 &read_default_group,
 					 &client_flag, &ssl,
-                     &local_infile
+					 &local_infile,
+					 &secure_auth
 #ifdef HAVE_MYSQL_OPT_TIMEOUTS
                      , &read_timeout
                      , &write_timeout
@@ -635,6 +639,11 @@ _mysql_ConnectionObject_Initialize(
 
 	if (local_infile != -1)
 		mysql_options(&(self->connection), MYSQL_OPT_LOCAL_INFILE, (char *) &local_infile);
+
+	if (secure_auth != -1) {
+		opt_secure_auth = secure_auth;
+		mysql_options(&(self->connection), MYSQL_SECURE_AUTH, (char *) &opt_secure_auth);
+	}
 
 #if HAVE_OPENSSL
 	if (ssl) {


### PR DESCRIPTION
Since MySQL 5.6.5 secure_auth default changed to ON, thus preventing connections using pre-4.1 password hashes.

Attemping to configure the option using read_default_file doesn't work because the MySQL API mishandles the secure_auth parameter (http://bugs.mysql.com/bug.php?id=75425).
