### PR TITLE
Remove hardcoded config and adapt to use 5.6 and 5.7 lib paths

### DIFF
--- a/site.cfg
+++ b/site.cfg
@@ -5,7 +5,7 @@
 
 embedded = False
 threadsafe = True
-static = False
+static = True
 
 # The path to mysql_config.
 # Only use this if mysql_config is not on your PATH, or you have some weird


### PR DESCRIPTION
Percona 5.7 puts binaries into `/usr/lib64/mysql/` whereas on 5.6 it puts dynamic ones in `/usr/lib64/` and static ones in `/usr/lib64/mysql/`. In 5.6 it also creates two sets of binaries, one prefixed with `perconaserver` and `mysql_config` points to the `perconaserver` binaries.
Also defaults to statically link. 