### PR TITLE
Use _binary prefix for bytes/bytearray parameters (now optional)

### DIFF
--- a/MySQLdb/__init__.py
+++ b/MySQLdb/__init__.py
@@ -27,6 +27,7 @@ apilevel = "2.0"
 paramstyle = "format"
 
 from _mysql import *
+from MySQLdb.compat import PY2
 from MySQLdb.constants import FIELD_TYPE
 from MySQLdb.times import Date, Time, Timestamp, \
     DateFromTicks, TimeFromTicks, TimestampFromTicks
@@ -72,8 +73,12 @@ def test_DBAPISet_set_equality_membership():
 def test_DBAPISet_set_inequality_membership():
     assert FIELD_TYPE.DATE != STRING
 
-def Binary(x):
-    return bytes(x)
+if PY2:
+    def Binary(x):
+        return bytearray(x)
+else:
+    def Binary(x):
+        return bytes(x)
 
 def Connect(*args, **kwargs):
     """Factory function for connections.Connection."""


### PR DESCRIPTION
This should hopefully address the problems of the previous attempt (#106, #123). An optional connection parameter is used to enable the behaviour. I've also added a unit test to check expected query parameter handling.