### PR TITLE
Add a read-only attribute to Cursor class which containing the body of the last query

### DIFF
--- a/MySQLdb/cursors.py
+++ b/MySQLdb/cursors.py
@@ -54,6 +54,7 @@ class BaseCursor(object):
     #: Max size of allowed statement is max_allowed_packet - packet_header_size.
     #: Default value of max_allowed_packet is 1048576.
     max_stmt_length = 64*1024
+    _query_literal = ""
 
     from _mysql_exceptions import MySQLError, Warning, Error, InterfaceError, \
          DatabaseError, DataError, OperationalError, IntegrityError, \
@@ -201,6 +202,10 @@ class BaseCursor(object):
             raise ProgrammingError("cursor closed")
         return con
 
+    @property
+    def query(self):
+        return self._query_literal
+
     def execute(self, query, args=None):
         """Execute a query.
 
@@ -241,6 +246,8 @@ class BaseCursor(object):
 
         if isinstance(query, unicode):
             query = query.encode(db.unicode_literal.charset, 'surrogateescape')
+        
+        self._query_literal = query
 
         res = None
         try:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mysqlclient
 
-[![Build Status](https://secure.travis-ci.org/PyMySQL/mysqlclient-python.png)](http://travis-ci.org/PyMySQL/mysqlclient-python)
+[![Build Status](https://travis-ci.org/lyqscmy/mysqlclient-python.svg?branch=master)](https://travis-ci.org/lyqscmy/mysqlclient-python)
 
 This is a fork of [MySQLdb1](https://github.com/farcepest/MySQLdb1).
 


### PR DESCRIPTION
In the Psycopg module(PostgreSQL driver for Python), Cursor class have a read-only attribute containing the body of the last [query](http://initd.org/psycopg/docs/cursor.html#cursor.query). It's useful when debugging in REPL.Extremely in the situation where Query SQL have Unicode characters.