### PR TITLE
Add CursorChunkFetchMixIn and two premixed cursors

### DIFF
--- a/MySQLdb/cursors.py
+++ b/MySQLdb/cursors.py
@@ -569,7 +569,8 @@ class CursorChunkFetchMixIn(CursorUseResultMixIn):
         """Fetch all available rows from cursor, append them to the store,
         and return the lot."""
         self._check_executed()
-        return tuple(self.store.extend(super().fetchall()))
+        self.store.extend(super().fetchall())
+        return tuple(self.store)
 
 
 class CursorTupleRowsMixIn(object):

--- a/MySQLdb/cursors.py
+++ b/MySQLdb/cursors.py
@@ -528,50 +528,50 @@ class CursorChunkFetchMixIn(CursorUseResultMixIn):
     one row at a time. The size of a chunk is equal to cursor.arraysize."""
 
     @property
-    def cache(self):
-        """The cache is a deque, created if missing."""
+    def store(self):
+        """The store is a deque, created if missing."""
         try:
-            return self._cache
+            return self._store
         except AttributeError:
-            self._cache = deque()
-            return self._cache
+            self._store = deque()
+            return self._store
 
-    @cache.setter
-    def cache(self, value):
-        self._cache = value
+    @store.setter
+    def store(self, value):
+        self._store = value
 
     def fetchone(self):
-        """Returns a row from the cursor's cache. If the cache is empty,
+        """Returns a row from the cursor's store. If the store is empty,
         fetches a new chunk and returns the first row. None indicates
         that no more rows are available."""
         self._check_executed()
-        if not self.cache:
+        if not self.store:
             if self.rownumber >= len(self._rows):
                 return None
             chunk = super().fetchmany()
             if not chunk:
                 self._warning_check()
                 return None
-            self.cache.extend(chunk)
-        return self.cache.popleft()
+            self.store.extend(chunk)
+        return self.store.popleft()
 
     def fetchmany(self, size=None):
-        """Return up to size rows from the cursor's cache. If the cache is empty,
+        """Return up to size rows from the cursor's store. If the store is empty,
         fetches up to size rows from cursor. Result set may be smaller
         than size. If size is not defined, cursor.arraysize is used."""
         self._check_executed()
-        if not self.cache:
+        if not self.store:
             return super().fetchmany(size)
         return tuple(
-            self.cache.popleft()
-            for _ in range(min(size, len(self.cache)))
+            self.store.popleft()
+            for _ in range(min(size, len(self.store)))
         )
 
     def fetchall(self):
-        """Fetch all available rows from cursor, append them to the cache,
+        """Fetch all available rows from cursor, append them to the store,
         and return the lot."""
         self._check_executed()
-        return tuple(self.cache.extend(super().fetchall()))
+        return tuple(self.store.extend(super().fetchall()))
 
 
 class CursorTupleRowsMixIn(object):
@@ -648,13 +648,13 @@ class ChunkingSSCursor(CursorChunkFetchMixIn, CursorTupleRowsMixIn,
                        BaseCursor):
     """This is a Cursor class that returns rows as tuples,
     stores the result set in the server, and fetches
-    in chunks (cached locally) for fetchone()."""
+    in chunks (stored locally) for fetchone()."""
 
 
 class ChunkingSSDictCursor(CursorChunkFetchMixIn, CursorDictRowsMixIn,
                            BaseCursor):
     """This is a Cursor class that returns rows as dictionaries,
     stores the result set in the server, and fetches
-    in chunks (cached locally) even for fetchone()."""
+    in chunks (stored locally) even for fetchone()."""
 
 

--- a/MySQLdb/cursors.py
+++ b/MySQLdb/cursors.py
@@ -4,6 +4,7 @@ This module implements Cursors of various types for MySQLdb. By
 default, MySQLdb uses the Cursor class.
 """
 from __future__ import print_function, absolute_import
+from collections import deque
 from functools import partial
 import re
 import sys
@@ -546,11 +547,8 @@ class CursorChunkFetchMixIn(CursorUseResultMixIn):
         that no more rows are available."""
         self._check_executed()
         if not self.store:
-            if self.rownumber >= len(self._rows):
-                return None
             chunk = super().fetchmany()
             if not chunk:
-                self._warning_check()
                 return None
             self.store.extend(chunk)
         return self.store.popleft()


### PR DESCRIPTION
This new mixin serves the purpose of allowing automatic chunking
of fetches when using a server-side cursor, allowing simple
iteration over the cursor without emitting one fetch per row, but
without needing to fetch everything at once either.

I have found it useful to make this occur automatically, where the
previous solution was to either use an ORM or nest two loops
(outer loop calling fetchmany).