### PR TITLE
Remove unused parameter from method definition

### DIFF
--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -297,7 +297,7 @@ class Connection(_mysql.connection):
             return b'_binary' + x
         return x
 
-    def _tuple_literal(self, t, d):
+    def _tuple_literal(self, t):
         return "(%s)" % (','.join(map(self.literal, t)))
 
     def literal(self, o):


### PR DESCRIPTION
This produced the error `TypeError: _tuple_literal() missing 1 required positional argument: 'd'` on line 316. Introduced in commit https://github.com/PyMySQL/mysqlclient-python/commit/ca4317a6b5ffc4c78c711123b52dfda400d00eb5, release [1.3.11](https://github.com/PyMySQL/mysqlclient-python/releases/tag/1.3.11).