### PR TITLE
Tiny/medium/long blobs are not converted correctly, MULTIPOLYGON test suite was checking against wrong value

### DIFF
--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -238,7 +238,8 @@ class Connection(_mysql.connection):
             self.set_sql_mode(sql_mode)
 
         if use_unicode:
-            for t in (FIELD_TYPE.STRING, FIELD_TYPE.VAR_STRING, FIELD_TYPE.VARCHAR, FIELD_TYPE.TINY_BLOB, FIELD_TYPE.MEDIUM_BLOB, FIELD_TYPE.LONG_BLOB, FIELD_TYPE.BLOB):
+            for t in (FIELD_TYPE.STRING, FIELD_TYPE.VAR_STRING, FIELD_TYPE.VARCHAR, FIELD_TYPE.TINY_BLOB,
+                      FIELD_TYPE.MEDIUM_BLOB, FIELD_TYPE.LONG_BLOB, FIELD_TYPE.BLOB):
                 self.converter[t].append((None, string_decoder))
 
         self.encoders[bytes] = string_literal

--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -238,10 +238,8 @@ class Connection(_mysql.connection):
             self.set_sql_mode(sql_mode)
 
         if use_unicode:
-            self.converter[FIELD_TYPE.STRING].append((None, string_decoder))
-            self.converter[FIELD_TYPE.VAR_STRING].append((None, string_decoder))
-            self.converter[FIELD_TYPE.VARCHAR].append((None, string_decoder))
-            self.converter[FIELD_TYPE.BLOB].append((None, string_decoder))
+            for t in (FIELD_TYPE.STRING, FIELD_TYPE.VAR_STRING, FIELD_TYPE.VARCHAR, FIELD_TYPE.TINY_BLOB, FIELD_TYPE.MEDIUM_BLOB, FIELD_TYPE.LONG_BLOB, FIELD_TYPE.BLOB):
+                self.converter[t].append((None, string_decoder))
 
         self.encoders[bytes] = string_literal
         self.encoders[unicode] = unicode_literal

--- a/tests/test_MySQLdb_capabilities.py
+++ b/tests/test_MySQLdb_capabilities.py
@@ -116,7 +116,7 @@ class test_MySQLdb(capabilities.DatabaseTest):
             c.execute("SELECT id, AsText(border) FROM test_MULTIPOLYGON")
             row = c.fetchone()
             self.assertEqual(row[0], 1)
-            self.assertEqual(row[1], b'MULTIPOLYGON(((1 1,1 -1,-1 -1,-1 1,1 1)),((1 1,3 1,3 3,1 3,1 1)))')
+            self.assertEqual(row[1], 'MULTIPOLYGON(((1 1,1 -1,-1 -1,-1 1,1 1)),((1 1,3 1,3 3,1 3,1 1)))')
 
             c.execute("SELECT id, AsWKB(border) FROM test_MULTIPOLYGON")
             row = c.fetchone()


### PR DESCRIPTION
When using use_unicode, results from tiny/medium/long blobs were not converted correctly.