### PR TITLE
Decode query result to support python 3

### DIFF
--- a/MySQLdb/cursors.py
+++ b/MySQLdb/cursors.py
@@ -443,6 +443,10 @@ class CursorStoreResultMixIn(object):
         else:
             result = self._rows
         self.rownumber = len(self._rows)
+        # to support python 3
+        if not PY2:
+            db = self._get_db()
+            result = tuple(tuple(word.decode(db.encoding) if isinstance(word, bytes) else word  for word in grant) for grant in result)
         return result
 
     def scroll(self, value, mode='relative'):


### PR DESCRIPTION
In python 3, result should be str object instead of bytes object.
This is to fix ```TypeError: a bytes-like object is required, not 'str'```