### PR TITLE
Reduce callproc roundtrip time

### DIFF
--- a/MySQLdb/cursors.py
+++ b/MySQLdb/cursors.py
@@ -349,9 +349,10 @@ class BaseCursor(object):
         """
 
         db = self._get_db()
-        for index, arg in enumerate(args):
-            q = "SET @_%s_%d=%s" % (procname, index,
-                                         db.literal(arg))
+        if args:
+            argFmt = '@_{0}_%d=%s'.format(procname)
+            q = 'SET %s' % ','.join(argFmt % (index, db.literal(arg))
+                                              for index, arg in enumerate(args))
             if isinstance(q, unicode):
                 q = q.encode(db.encoding, 'surrogateescape')
             self._query(q)

--- a/MySQLdb/cursors.py
+++ b/MySQLdb/cursors.py
@@ -350,9 +350,9 @@ class BaseCursor(object):
 
         db = self._get_db()
         if args:
-            argFmt = '@_{0}_%d=%s'.format(procname)
-            q = 'SET %s' % ','.join(argFmt % (index, db.literal(arg))
-                                              for index, arg in enumerate(args))
+            fmt = '@_{0}_%d=%s'.format(procname)
+            q = 'SET %s' % ','.join(fmt % (index, db.literal(arg))
+                                    for index, arg in enumerate(args))
             if isinstance(q, unicode):
                 q = q.encode(db.encoding, 'surrogateescape')
             self._query(q)


### PR DESCRIPTION
(Equivalent of https://github.com/PyMySQL/PyMySQL/pull/636, for this module.)

Rather than making an individual SET query for each and every parameter specified for a callproc call, use one single call instead, saving round-trip time (if one has more than one parameter). This can be significant if one is making many repeated callproc calls which have multiple arguments.

Then only downside I can think of is that if one or more arguments are quite large, combining them all could hit the max_allowed_packet limit. However, if it is only e.g. one large argument this will make next to no difference and the user should have an increased max_allowed_packet value in anticipation of e.g. larger blobs already.