### PR TITLE
Add support for converting sets

### DIFF
--- a/MySQLdb/converters.py
+++ b/MySQLdb/converters.py
@@ -91,6 +91,9 @@ def quote_tuple(t, d):
 
 # bytes or str regarding to BINARY_FLAG.
 _bytes_or_str = [(FLAG.BINARY, bytes)]
+_bytes_or_str_or_set = _bytes_or_str + [
+    (FLAG.SET, Str2Set),
+]
 
 conversions = {
     int: Thing2Str,
@@ -125,7 +128,7 @@ conversions = {
     FIELD_TYPE.MEDIUM_BLOB: _bytes_or_str,
     FIELD_TYPE.LONG_BLOB: _bytes_or_str,
     FIELD_TYPE.BLOB: _bytes_or_str,
-    FIELD_TYPE.STRING: _bytes_or_str,
+    FIELD_TYPE.STRING: _bytes_or_str_or_set,
     FIELD_TYPE.VAR_STRING: _bytes_or_str,
     FIELD_TYPE.VARCHAR: _bytes_or_str,
 }

--- a/MySQLdb/converters.py
+++ b/MySQLdb/converters.py
@@ -49,7 +49,7 @@ except AttributeError:
 def Bool2Str(s, d): return str(int(s))
 
 def Str2Set(s):
-    return set([ i for i in s.split(',') if i ])
+    return set([ i for i in s.decode().split(',') if i ])
 
 def Set2Str(s, d):
     # Only support ascii string.  Not tested.


### PR DESCRIPTION
For a column defined as `SET('A', 'B')`, the C library returns `FIELD_TYPE_STRING` and `FLAG_SET` instead of `FIELD_TYPE_SET`. This leads to values being converted to a string (with comma-separated values) instead of a proper Python set. Adding a mapping that watches for `FLAG_SET` fixes the issue.

This has been confirmed manually with MySQL 5.6.10 by setting a custom converter:
```python
@staticmethod
def __convert_mysql_set_to_python_set(value):
    values = value.decode().split(',')
    values = [str(v) for v in values]
    return values

def __get_connection(self):
    conv = MySQLdb.converters.conversions.copy()
    conv[FIELD_TYPE.STRING].append((FLAG.SET, self.__convert_mysql_set_to_python_set))
    return MySQLdb.connect(
        host='127.0.0.1',
        port=3306,
        user='some_user',
        passwd='some_passwd',
        db='some_db',
        conv=conv
    )
```
However, notice that the custom function passed into `conv` uses `decode()` on the passed value. Simply reusing `MySQLdb.converters.Str2Set` doesn't actually work for me when encountering a `SET`:
```
  File "/usr/local/lib/python3.5/site-packages/MySQLdb/converters.py", line 52, in Str2Set
    return set([ i for i in s.split(',') if i ])
TypeError: a bytes-like object is required, not 'str'
```
@methane: Is it safe to amend the `Str2Set` function? Has it actually ever worked?