### PR TITLE
Only delete cursor if it exists.

### DIFF
--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -42,9 +42,9 @@ def defaulterrorhandler(connection, cursor, errorclass, errorvalue):
     error = errorclass, errorvalue
     if cursor:
         cursor.messages.append(error)
+        del cursor
     else:
         connection.messages.append(error)
-    del cursor
     del connection
     if isinstance(errorvalue, BaseException):
         raise errorvalue


### PR DESCRIPTION
Responsible for a chromium bug: https://bugs.chromium.org/p/chromium/issues/detail?id=826534

> There are huge amount of the following exceptions in the apache logs:
> "'NoneType' object is not callable" in <bound method Cursor.__del__ of <MySQLdb.cursors.Cursor object 
