### PR TITLE
Change default build option to use static linking

### DIFF
--- a/setup_posix.py
+++ b/setup_posix.py
@@ -41,16 +41,12 @@ def get_config():
     static = enabled(options, 'static')
     if enabled(options, 'embedded'):
         libs = mysql_config("libmysqld-libs")
-        client = "mysqld"
     elif enabled(options, 'threadsafe'):
         libs = mysql_config("libs_r")
-        client = "mysqlclient_r"
         if not libs:
             libs = mysql_config("libs")
-            client = "mysqlclient"
     else:
         libs = mysql_config("libs")
-        client = "mysqlclient"
 
     library_dirs = [dequote(i[2:]) for i in libs if i.startswith('-L')]
     libraries = [dequote(i[2:]) for i in libs if i.startswith('-l')]
@@ -67,6 +63,16 @@ def get_config():
 
     include_dirs = [dequote(i[2:])
                     for i in mysql_config('include') if i.startswith('-I')]
+
+
+    # properly handle mysql client libraries that are not called libmysqlclient
+    client = None
+    CLIENT_LIST = ['mysqlclient', 'mysqlclient_r', 'mysqld',
+                   'perconaserverclient', 'perconaserverclient_r']
+    for c in CLIENT_LIST:
+        if c in libraries:
+            client = c
+            break
 
     if static:
         extra_objects.append(os.path.join(library_dirs[0], 'lib%s.a' % client))

--- a/site.cfg
+++ b/site.cfg
@@ -5,7 +5,7 @@
 
 embedded = False
 threadsafe = True
-static = False
+static = True
 
 # The path to mysql_config.
 # Only use this if mysql_config is not on your PATH, or you have some weird


### PR DESCRIPTION
The problem that this addresses is the case when you have both libmysqlclient and libperconaserverclient on the same machine from two different versions of MySQL.  On ubuntu 12, client libraries from Percona for both 5.5 and 5.6 are called libmysqlclient.so, but on ubuntu 14 and newer (and probably also CentOS/RHEL), they changed their package name to libperconaserverclient.

What makes it worse is that in later versions of Percona Server, the package names change again, so that there is libperconaserverclient18, libperconaserverclient18.1, and libperconaserverclient20 for MySQL 5.5, 5.6, and 5.7, respectively, and it is far too easy to get into symbol-mismatch and version hell - even moreso if you have a mixed environment where some hosts are ubuntu X and others are ubuntu Y.

All of this might not be an issue that anyone would ever hit unless they are attempting to use LOAD DATA LOCAL INFILE with a 5.5 library against a 5.6 (or newer) server; in that case, MySQL will return error 1148: The used command is not allowed with this MySQL version.