### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ I hope this fork is merged back to MySQLdb1 like distribute was merged back to s
 
 You may need to install the Python and MySQL development headers and libraries like so:
 
-* `sudo apt-get install python-dev libmysqlclient-dev`  # Debian / Ubuntu
+* `sudo apt-get install python-dev default-libmysqlclient-dev`  # Debian / Ubuntu
 * `sudo yum install python-devel mysql-devel`  # Red Hat / CentOS
 * `brew install mysql-connector-c`  # macOS (Homebrew)  (Currently, it has bug. See below)
 
-On Windows, there are binary wheels you can install without MySQLConnector/C or MSVC. 
+On Windows, there are binary wheels you can install without MySQLConnector/C or MSVC.
 
 #### Note on Python 3 : if you are using python3 then you need to install python3-dev using the following command :
 
@@ -31,21 +31,21 @@ See also: https://bugs.mysql.com/bug.php?id=86971
 
 Versions of MySQL Connector/C may have incorrect default configuration options that cause compilation errors when `mysqlclient-python` is installed.  (As of November 2017, this is known to be true for homebrew's `mysql-connector-c` and [official package](https://dev.mysql.com/downloads/connector/c/))
 
-Modification of `mysql_config` resolves these issues as follows. 
+Modification of `mysql_config` resolves these issues as follows.
 
 Change
 
 ```
 # on macOS, on or about line 112:
-# Create options 
+# Create options
 libs="-L$pkglibdir"
 libs="$libs -l "
 ```
 
-to 
+to
 
 ```
-# Create options 
+# Create options
 libs="-L$pkglibdir"
 libs="$libs -lmysqlclient -lssl -lcrypto"
 ```


### PR DESCRIPTION
`libmysqliclient-dev` package isn't available in Debian (Stretch) anymore.
It's better to use metapackage for installation because it this package is available Ubuntu and Debian.

**Debian:**
```
apt search libmysqlclient-dev
Sorting... Done
Full Text Search... Done
default-libmysqlclient-dev/stable 1.0.2 amd64
  MySQL database development files (metapackage)

```

**Ubuntu:**
```
apt search libmysqlclient
Sorting... Done
Full Text Search... Done
default-libmysqlclient-dev/bionic 1.0.4 amd64
  MySQL database development files (metapackage)

libmariadbclient-dev-compat/bionic 1:10.1.29-6 amd64
  MariaDB database development files (libmysqlclient compatibility)

libmysqlclient-dev/bionic-updates,bionic-security 5.7.22-0ubuntu18.04.1 amd64
  MySQL database development files

libmysqlclient20/bionic-updates,bionic-security 5.7.22-0ubuntu18.04.1 amd64
  MySQL database client library
```