### PR TITLE
Fixing python3-bytes-error via salt

### DIFF
--- a/MySQLdb/cursors.py
+++ b/MySQLdb/cursors.py
@@ -22,6 +22,23 @@ else:
     text_type = str
 
 
+def convert_to_str(var):
+    """
+    Convert various datatypes to str
+    Required for Python 3
+    """
+    if isinstance(var,tuple):
+        return tuple(convert_to_str(item) for item in var)
+    if isinstance(var,list):
+        return ([convert_to_str(item) for item in var])
+    elif isinstance(var,dict):
+        return {convert_to_str(key):convert_to_str(value) for key,value in var.items()}
+    elif isinstance(var,bytes):
+        return var.decode('utf-8')
+    
+    return var
+
+
 #: Regular expression for :meth:`Cursor.executemany`.
 #: executemany only supports simple bulk insert.
 #: You can use it to load large dataset.
@@ -444,6 +461,9 @@ class CursorStoreResultMixIn(object):
         else:
             result = self._rows
         self.rownumber = len(self._rows)
+        if not PY2:
+            db = self._get_db()
+            result = tuple(convert_to_str(result))
         return result
 
     def scroll(self, value, mode='relative'):

--- a/MySQLdb/cursors.py
+++ b/MySQLdb/cursors.py
@@ -34,7 +34,7 @@ def convert_to_str(var):
     elif isinstance(var,dict):
         return {convert_to_str(key):convert_to_str(value) for key,value in var.items()}
     elif isinstance(var,bytes):
-        return var.decode('utf-8')
+        return var.decode('utf-8', 'ignore')
     
     return var
 


### PR DESCRIPTION
In using PyMySQL with Python3, I encountered a [TypeError issue](https://github.com/saltstack/salt/issues/45026) that has been known since last year for Saltstack users.  It doesn't appear this was submitted as a pull request. 

I have deployed this patch on my test server with python3 but does not interfere with python2.  It does fix the Type Error.
