### PR TITLE
Fixed float adapter.

### DIFF
--- a/MySQLdb/converters.py
+++ b/MySQLdb/converters.py
@@ -66,7 +66,7 @@ def Unicode2Str(s, d):
     return s.encode()
 
 def Float2Str(o, d):
-    return '%.15g' % o
+    return '%.16e' % o
 
 def None2NULL(o, d):
     """Convert None to NULL."""

--- a/tests/capabilities.py
+++ b/tests/capabilities.py
@@ -279,3 +279,9 @@ class DatabaseTest(unittest.TestCase):
                  ('col1 INT','col2 BLOB'),
                  generator)
 
+    def test_DOUBLE(self):
+        for val in (18014398509481982.0, 0.1):
+            self.cursor.execute('SELECT %s', (val,));
+            result = self.cursor.fetchone()[0]
+            self.assertEqual(result, val)
+            self.assertIsInstance(result, float)


### PR DESCRIPTION
IEEE 754 double needs to be formatted with 17 decimal digits to guarantee lossless round-trip.
So this doesn't work currently:
```
In [125]: import MySQLdb

In [126]: con = MySQLdb.connect()

In [127]: cursor = con.cursor()

In [128]: val = 18014398509481982.

In [129]: val
Out[129]: 1.8014398509481982e+16

In [130]: cursor.execute("SELECT %s", (val,))
Out[130]: 1

In [131]: result = cursor.fetchone()[0]

In [132]: result
Out[132]: 1.8014398509482e+16

In [133]: result == val
Out[133]: False
```