### PR TITLE
Added method get_native_connection: it retrieves a PyCapsule with MYSQL* C native pointer inside

### DIFF
--- a/_mysql.c
+++ b/_mysql.c
@@ -1686,6 +1686,24 @@ _mysql_ConnectionObject_get_character_set_info(
 }
 #endif
 
+static char _mysql_ConnectionObject_get_native_connection__doc__[] =
+"Return the internal MYSQL* wrapped in a PyCapsule object.\n\
+";
+
+static PyObject *
+_mysql_ConnectionObject_get_native_connection(
+	_mysql_ConnectionObject *self,
+	PyObject *noargs)
+{
+	PyObject *result;
+
+	check_connection(self);
+        result = PyCapsule_New(&(self->connection), 
+                 "_mysql.connection.native_connection", NULL);
+	return result;
+}
+
+
 static char _mysql_get_client_info__doc__[] =
 "get_client_info() -- Returns a string that represents\n\
 the client library version.";
@@ -2271,6 +2289,12 @@ static PyMethodDef _mysql_ConnectionObject_methods[] = {
 		_mysql_ConnectionObject_get_character_set_info__doc__
 	},
 #endif
+	{
+		"get_native_connection",
+		(PyCFunction)_mysql_ConnectionObject_get_native_connection,
+		METH_NOARGS,
+		_mysql_ConnectionObject_get_native_connection__doc__
+	},
 	{
 		"close",
 		(PyCFunction)_mysql_ConnectionObject_close,


### PR DESCRIPTION
This extension is necessary to retrieve MYSQL * C native pointer from the underlying C API and pass it to another Python module that requires it.
A PyCapsule object is used to retrieve the pointer.
A use case is described here: https://stackoverflow.com/questions/52687294/how-to-retrieve-mysql-native-connection-from-mysql-and-or-mysqldb-connection#
I have used the same method name that Psycopg2 is introducing in the next version: https://github.com/fogzot/psycopg2/commit/81addddaee2c690e925bb8f381e7bcb02ca97687

Kind Regards
Ch.F.