### PR TITLE
Fix conversion of decimals with exponent.

### DIFF
--- a/MySQLdb/converters.py
+++ b/MySQLdb/converters.py
@@ -82,6 +82,8 @@ def Thing2Literal(o, d):
     that method when the connection is created."""
     return string_literal(o, d)
 
+def Decimal2Literal(o, d):
+    return format(o, 'f')
 
 def char_array(s):
     return array.array('c', s)
@@ -142,6 +144,6 @@ try:
     from decimal import Decimal
     conversions[FIELD_TYPE.DECIMAL] = Decimal
     conversions[FIELD_TYPE.NEWDECIMAL] = Decimal
-    conversions[Decimal] = Thing2Str
+    conversions[Decimal] = Decimal2Literal
 except ImportError:
     pass

--- a/tests/capabilities.py
+++ b/tests/capabilities.py
@@ -202,6 +202,12 @@ class DatabaseTest(unittest.TestCase):
             ('col1 DECIMAL(5,2)',),
             generator)
 
+        val = Decimal('1.11111111111111119E-7')
+        self.cursor.execute('SELECT %s', (val,))
+        result = self.cursor.fetchone()[0]
+        self.assertEqual(result, val)
+        self.assertIsInstance(result, Decimal)
+
         self.cursor.execute('SELECT %s + %s', (Decimal('0.1'), Decimal('0.2')))
         result = self.cursor.fetchone()[0]
         self.assertEqual(result, Decimal('0.3'))


### PR DESCRIPTION
Converter for `Decimal` implemented in #267 doesn't handle of `Decimal`s with exponent:

```
In [7]: str(Decimal('1e1'))
Out[7]: '1E+1'
```

This PR makes it to be formatted in the other way:

```
In [16]: format(Decimal('1e1'), 'f')
Out[16]: '10'
```

It seems that it's not documented well how `Decimal.__format__()` works (https://bugs.python.org/issue23460 could be related), and I found this formatting in [python-list](https://mail.python.org/pipermail/python-list/2009-December/562330.html).

@methane, apologies for not handling this at once.