### PR TITLE
Expose the file descriptor of the underlying libmysqlclient connection.

### DIFF
--- a/MySQLdb/_mysql.c
+++ b/MySQLdb/_mysql.c
@@ -1639,6 +1639,20 @@ _mysql_ConnectionObject_field_count(
     return PyInt_FromLong((long)mysql_field_count(&(self->connection)));
 }
 
+static char _mysql_ConnectionObject_fileno__doc__[] =
+"Return file descriptor of the underlying libmysqlclient connection.\n\
+This provides raw access to the underlying network connection.\n\
+";
+
+static PyObject *
+_mysql_ConnectionObject_fileno(
+    _mysql_ConnectionObject *self,
+    PyObject *noargs)
+{
+    check_connection(self);
+    return PyInt_FromLong(self->connection.net.fd);
+}
+
 static char _mysql_ResultObject_num_fields__doc__[] =
 "Returns the number of fields (column) in the result." ;
 
@@ -2132,6 +2146,12 @@ static PyMethodDef _mysql_ConnectionObject_methods[] = {
         (PyCFunction)_mysql_ConnectionObject_field_count,
         METH_NOARGS,
         _mysql_ConnectionObject_field_count__doc__
+    },
+    {
+        "fileno",
+        (PyCFunction)_mysql_ConnectionObject_fileno,
+        METH_NOARGS,
+        _mysql_ConnectionObject_fileno__doc__
     },
     {
         "get_host_info",

--- a/tests/test_MySQLdb_nonstandard.py
+++ b/tests/test_MySQLdb_nonstandard.py
@@ -103,3 +103,6 @@ class CoreAPI(unittest.TestCase):
             conn.client_flag = 0
 
         conn.close()
+
+    def test_fileno(self):
+        self.assertGreaterEqual(self.conn.fileno(), 0)


### PR DESCRIPTION
Add a fileno() method to _mysql.connection. This permits low-level access to the
underlying network connection. My specific usecase for this is wanting to tweak
the TCP timeout (TCP_USER_TIMEOUT).