### PR TITLE
Stop using surrogate escape.

### DIFF
--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -171,21 +171,8 @@ class Connection(_mysql.connection):
         self.encoding = 'ascii'  # overridden in set_character_set()
         db = proxy(self)
 
-        # Note: string_literal() is called for bytes object on Python 3 (via bytes_literal)
-        def string_literal(obj, dummy=None):
-            return db.string_literal(obj)
-
-        if PY2:
-            # unicode_literal is called for only unicode object.
-            def unicode_literal(u, dummy=None):
-                return db.string_literal(u.encode(db.encoding))
-        else:
-            # unicode_literal() is called for arbitrary object.
-            def unicode_literal(u, dummy=None):
-                return db.string_literal(str(u).encode(db.encoding))
-
-        def bytes_literal(obj, dummy=None):
-            return b'_binary' + db.string_literal(obj)
+        def unicode_literal(u, dummy=None):
+            return db.string_literal(u.encode(db.encoding))
 
         def string_decoder(s):
             return s.decode(db.encoding)
@@ -202,7 +189,6 @@ class Connection(_mysql.connection):
                       FIELD_TYPE.MEDIUM_BLOB, FIELD_TYPE.LONG_BLOB, FIELD_TYPE.BLOB):
                 self.converter[t].append((None, string_decoder))
 
-        self.encoders[bytes] = string_literal
         self.encoders[unicode] = unicode_literal
         self._transactional = self.server_capabilities & CLIENT.TRANSACTIONS
         if self._transactional:

--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -248,7 +248,9 @@ class Connection(_mysql.connection):
         Non-standard. For internal use; do not use this in your
         applications.
         """
-        if isinstance(o, bytearray):
+        if isinstance(o, unicode):
+            s = self.string_literal(o.encode(self.encoding))
+        elif isinstance(o, bytearray):
             s = self._bytes_literal(o)
         elif not PY2 and isinstance(o, bytes):
             s = self._bytes_literal(o)

--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -258,6 +258,8 @@ class Connection(_mysql.connection):
             s = self._tuple_literal(o)
         else:
             s = self.escape(o, self.encoders)
+            if isinstance(s, unicode):
+                s = s.encode(self.encoding)
         assert isinstance(s, bytes)
         return s
 

--- a/MySQLdb/converters.py
+++ b/MySQLdb/converters.py
@@ -53,7 +53,7 @@ def Str2Set(s):
 
 def Set2Str(s, d):
     # Only support ascii string.  Not tested.
-    return string_literal(','.join(s), d)
+    return string_literal(','.join(s))
 
 def Thing2Str(s, d):
     """Convert something into a string via str()."""
@@ -80,7 +80,7 @@ def Thing2Literal(o, d):
     MySQL-3.23 or newer, string_literal() is a method of the
     _mysql.MYSQL object, and this function will be overridden with
     that method when the connection is created."""
-    return string_literal(o, d)
+    return string_literal(o)
 
 def Decimal2Literal(o, d):
     return format(o, 'f')

--- a/MySQLdb/cursors.py
+++ b/MySQLdb/cursors.py
@@ -189,7 +189,7 @@ class BaseCursor(object):
             except TypeError as m:
                 raise ProgrammingError(str(m))
 
-        assert isinstance(query, bytes)
+        assert isinstance(query, (bytes, bytearray))
         res = self._query(query)
         return res
 

--- a/MySQLdb/cursors.py
+++ b/MySQLdb/cursors.py
@@ -15,13 +15,6 @@ from ._mysql_exceptions import (
     NotSupportedError, ProgrammingError)
 
 
-PY2 = sys.version_info[0] == 2
-if PY2:
-    text_type = unicode
-else:
-    text_type = str
-
-
 #: Regular expression for :meth:`Cursor.executemany`.
 #: executemany only supports simple bulk insert.
 #: You can use it to load large dataset.
@@ -95,31 +88,28 @@ class BaseCursor(object):
         del exc_info
         self.close()
 
-    def _ensure_bytes(self, x, encoding=None):
-        if isinstance(x, text_type):
-            x = x.encode(encoding)
-        elif isinstance(x, (tuple, list)):
-            x = type(x)(self._ensure_bytes(v, encoding=encoding) for v in x)
-        return x
-
     def _escape_args(self, args, conn):
-        ensure_bytes = partial(self._ensure_bytes, encoding=conn.encoding)
+        encoding = conn.encoding
+        literal = conn.literal
+
+        def ensure_bytes(x):
+            if isinstance(x, unicode):
+                return x.encode(encoding)
+            elif isinstance(x, tuple):
+                return tuple(map(ensure_bytes, x))
+            elif isinstance(x, list):
+                return list(map(ensure_bytes, x))
+            return x
 
         if isinstance(args, (tuple, list)):
-            if PY2:
-                args = tuple(map(ensure_bytes, args))
-            return tuple(conn.literal(arg) for arg in args)
+            return tuple(literal(ensure_bytes(arg)) for arg in args)
         elif isinstance(args, dict):
-            if PY2:
-                args = dict((ensure_bytes(key), ensure_bytes(val)) for
-                            (key, val) in args.items())
-            return dict((key, conn.literal(val)) for (key, val) in args.items())
+            return {ensure_bytes(key): literal(ensure_bytes(val))
+                    for (key, val) in args.items()}
         else:
             # If it's not a dictionary let's try escaping it anyways.
             # Worst case it will throw a Value error
-            if PY2:
-                args = ensure_bytes(args)
-            return conn.literal(args)
+            return literal(ensure_bytes(args))
 
     def _check_executed(self):
         if not self._executed:
@@ -186,14 +176,7 @@ class BaseCursor(object):
             pass
         db = self._get_db()
 
-        # NOTE:
-        # Python 2: query should be bytes when executing %.
-        # All unicode in args should be encoded to bytes on Python 2.
-        # Python 3: query should be str (unicode) when executing %.
-        # All bytes in args should be decoded with ascii and surrogateescape on Python 3.
-        # db.literal(obj) always returns str.
-
-        if PY2 and isinstance(query, unicode):
+        if isinstance(query, unicode):
             query = query.encode(db.encoding)
 
         if args is not None:
@@ -201,16 +184,12 @@ class BaseCursor(object):
                 args = dict((key, db.literal(item)) for key, item in args.items())
             else:
                 args = tuple(map(db.literal, args))
-            if not PY2 and isinstance(query, (bytes, bytearray)):
-                query = query.decode(db.encoding)
             try:
                 query = query % args
             except TypeError as m:
                 raise ProgrammingError(str(m))
 
-        if isinstance(query, unicode):
-            query = query.encode(db.encoding, 'surrogateescape')
-
+        assert isinstance(query, bytes)
         res = self._query(query)
         return res
 
@@ -247,29 +226,19 @@ class BaseCursor(object):
     def _do_execute_many(self, prefix, values, postfix, args, max_stmt_length, encoding):
         conn = self._get_db()
         escape = self._escape_args
-        if isinstance(prefix, text_type):
+        if isinstance(prefix, unicode):
             prefix = prefix.encode(encoding)
-        if PY2 and isinstance(values, text_type):
+        if isinstance(values, unicode):
             values = values.encode(encoding)
-        if isinstance(postfix, text_type):
+        if isinstance(postfix, unicode):
             postfix = postfix.encode(encoding)
         sql = bytearray(prefix)
         args = iter(args)
         v = values % escape(next(args), conn)
-        if isinstance(v, text_type):
-            if PY2:
-                v = v.encode(encoding)
-            else:
-                v = v.encode(encoding, 'surrogateescape')
         sql += v
         rows = 0
         for arg in args:
             v = values % escape(arg, conn)
-            if isinstance(v, text_type):
-                if PY2:
-                    v = v.encode(encoding)
-                else:
-                    v = v.encode(encoding, 'surrogateescape')
             if len(sql) + len(v) + len(postfix) + 1 > max_stmt_length:
                 rows += self.execute(sql + postfix)
                 sql = bytearray(prefix)
@@ -308,22 +277,19 @@ class BaseCursor(object):
         to advance through all result sets; otherwise you may get
         disconnected.
         """
-
         db = self._get_db()
+        if isinstance(procname, unicode):
+            procname = procname.encode(db.encoding)
         if args:
-            fmt = '@_{0}_%d=%s'.format(procname)
-            q = 'SET %s' % ','.join(fmt % (index, db.literal(arg))
-                                    for index, arg in enumerate(args))
-            if isinstance(q, unicode):
-                q = q.encode(db.encoding, 'surrogateescape')
+            fmt = b'@_' + procname + b'_%d=%s'
+            q = b'SET %s' % b','.join(fmt % (index, db.literal(arg))
+                                      for index, arg in enumerate(args))
             self._query(q)
             self.nextset()
 
-        q = "CALL %s(%s)" % (procname,
-                             ','.join(['@_%s_%d' % (procname, i)
-                                       for i in range(len(args))]))
-        if isinstance(q, unicode):
-            q = q.encode(db.encoding, 'surrogateescape')
+        q = b"CALL %s(%s)" % (procname,
+                              b','.join([b'@_%s_%d' % (procname, i)
+                                         for i in range(len(args))]))
         self._query(q)
         return args
 

--- a/MySQLdb/times.py
+++ b/MySQLdb/times.py
@@ -124,11 +124,11 @@ def Date_or_None(s):
 
 def DateTime2literal(d, c):
     """Format a DateTime object as an ISO timestamp."""
-    return string_literal(format_TIMESTAMP(d), c)
+    return string_literal(format_TIMESTAMP(d))
 
 def DateTimeDelta2literal(d, c):
     """Format a DateTimeDelta object as a time."""
-    return string_literal(format_TIMEDELTA(d),c)
+    return string_literal(format_TIMEDELTA(d))
 
 def mysql_timestamp_converter(s):
     """Convert a MySQL TIMESTAMP to a Timestamp object."""


### PR DESCRIPTION
It was workaround for `bytes %`.
Since we dropped Python 3.4 support, we can use just `bytes %` now.