### PR TITLE
Add some garbage for Django 1.11 compatibility

### DIFF
--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -166,6 +166,14 @@ class Connection(_mysql.connection):
         self.encoders = dict([ (k, v) for k, v in conv.items()
                                if type(k) is not int ])
 
+        # XXX THIS IS GARBAGE: While this is just a garbage and undocumented,
+        # Django 1.11 depends on it.  And they don't fix it because
+        # they are in security-only fix mode.
+        # So keep this garbage for now.  This will be removed in 1.5.
+        # See PyMySQL/mysqlclient-python#306
+        self.encoders[unicode] = unicode
+        self.encoders[bytes] = bytes
+
         self._server_version = tuple([ numeric_part(n) for n in self.get_server_info().split('.')[:2] ])
 
         self.encoding = 'ascii'  # overridden in set_character_set()

--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -171,7 +171,6 @@ class Connection(_mysql.connection):
         # they are in security-only fix mode.
         # So keep this garbage for now.  This will be removed in 1.5.
         # See PyMySQL/mysqlclient-python#306
-        self.encoders[unicode] = unicode
         self.encoders[bytes] = bytes
 
         self._server_version = tuple([ numeric_part(n) for n in self.get_server_info().split('.')[:2] ])

--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -245,8 +245,11 @@ class Connection(_mysql.connection):
             s = self.string_literal(o.encode(self.encoding))
         elif isinstance(o, bytearray):
             s = self._bytes_literal(o)
-        elif not PY2 and isinstance(o, bytes):
-            s = self._bytes_literal(o)
+        elif isinstance(o, bytes):
+            if PY2:
+                s = self.string_literal(o)
+            else:
+                s = self._bytes_literal(o)
         elif isinstance(o, (tuple, list)):
             s = self._tuple_literal(o)
         else:

--- a/MySQLdb/cursors.py
+++ b/MySQLdb/cursors.py
@@ -63,6 +63,14 @@ class BaseCursor(object):
         self.rowcount = -1
         self.arraysize = 1
         self._executed = None
+
+        # XXX THIS IS GARBAGE: While this is totally garbage and private,
+        # Django 1.11 depends on it.  And they don't fix it because
+        # they are in security-only fix mode.
+        # So keep this garbage for now.  This will be removed in 1.5.
+        # See PyMySQL/mysqlclient-python#303
+        self._last_executed = None
+
         self.lastrowid = None
         self.messages = []
         self._result = None
@@ -300,6 +308,7 @@ class BaseCursor(object):
         self._do_get_result(db)
         self._post_get_result()
         self._executed = q
+        self._last_executed = q  # XXX THIS IS GARBAGE: See above.
         return self.rowcount
 
     def _fetch_row(self, size=1):


### PR DESCRIPTION
Django touched private area of this library.
Removing unused variables broke Django.

While Django 2.0 fixed it, Django 1.11 LTS doesn't fix it
because Django 1.11 is in security-only fix mode.

So add unused variables for Django 1.11 compatibility.
They will be removed in 1.5.

Fix #303, #306