### PR TITLE
Bug in _mysql_field_to_python

### DIFF
--- a/MySQLdb/_mysql.c
+++ b/MySQLdb/_mysql.c
@@ -1147,6 +1147,7 @@ _mysql_field_to_python(
 #endif
         // Call converter with bytes
         binary = 1;
+        break;
     default: // e.g. FIELD_TYPE_DATETIME, etc.
         // Call converter with unicode string
         binary = 0;


### PR DESCRIPTION
when callback conversion is used the value is always passed as Str. 

Missing break; 

Turns out this was just reported. #343