### PR TITLE
Add some gc safety around _mysql__fetch_row

### DIFF
--- a/MySQLdb/_mysql.c
+++ b/MySQLdb/_mysql.c
@@ -1284,8 +1284,10 @@ _mysql__fetch_row(
         if (!self->use)
             row = mysql_fetch_row(self->result);
         else {
-            // This is to prevent gc.get_referrers shenanigans from causing
-            // the _PyTuple_Resize below from raising a SystemError
+            // see: https://docs.python.org/3/library/gc.html#gc.get_referrers
+            // This function can get a reference to the tuple r, and if that
+            // code is preempted while holding a ref to r, the _PyTuple_Resize
+            // will raise a SystemError because the ref count is 2.
             PyObject_GC_UnTrack(*r);
             Py_BEGIN_ALLOW_THREADS;
             row = mysql_fetch_row(self->result);

--- a/MySQLdb/_mysql.c
+++ b/MySQLdb/_mysql.c
@@ -1284,9 +1284,13 @@ _mysql__fetch_row(
         if (!self->use)
             row = mysql_fetch_row(self->result);
         else {
+            // This is to prevent gc.get_referrers shenanigans from causing
+            // the _PyTuple_Resize below from raising a SystemError
+            PyObject_GC_UnTrack(*r);
             Py_BEGIN_ALLOW_THREADS;
             row = mysql_fetch_row(self->result);
             Py_END_ALLOW_THREADS;
+            PyObject_GC_Track(*r);
         }
         if (!row && mysql_errno(&(((_mysql_ConnectionObject *)(self->conn))->connection))) {
             _mysql_Exception((_mysql_ConnectionObject *)self->conn);


### PR DESCRIPTION
Users of gc.get_referrers() could cause a SystemError to be raised if this function is running in a different python thread.

We ended up doing this at Facebook just to be safe, because it was really hard figuring out that it was not a _mysql issue but usage of gc.get_referrers() in a multi-threaded environment. but I understand if you don't feel its needed. 