### PR TITLE
memory leak in ConnectionObject_Initialize when mysql_real_connect returns NULL

### DIFF
--- a/MySQLdb/_mysql.c
+++ b/MySQLdb/_mysql.c
@@ -446,6 +446,8 @@ _mysql_ConnectionObject_Initialize(
 
     Py_BEGIN_ALLOW_THREADS ;
     conn = mysql_init(&(self->connection));
+    if (!conn)
+        return PyErr_NoMemory()
     self->open = 1;
     if (connect_timeout) {
         unsigned int timeout = connect_timeout;
@@ -497,7 +499,6 @@ _mysql_ConnectionObject_Initialize(
 
     if (!conn) {
         _mysql_Exception(self);
-        self->open = 0;
         return -1;
     }
 


### PR DESCRIPTION
Looking at mysql_real_connect on failure it does not free the memory of the passed in MYSQL* struct. only mysql_close does that.
So we can't set open=0 after we mysql_init or dealloc will not cleanup the memory.

Also if mysql_init returns NULL we are out of memory and shouldn't set open=1, or we could segfault in dealloc if we didn't seg before that.