### PR TITLE
memory leak in ConnectionObject_Initialize when mysql_real_connect fails

### DIFF
--- a/MySQLdb/_mysql.c
+++ b/MySQLdb/_mysql.c
@@ -446,6 +446,8 @@ _mysql_ConnectionObject_Initialize(
 
     Py_BEGIN_ALLOW_THREADS ;
     conn = mysql_init(&(self->connection));
+    if (!conn)
+        return PyErr_NoMemory();
     self->open = 1;
     if (connect_timeout) {
         unsigned int timeout = connect_timeout;
@@ -497,7 +499,6 @@ _mysql_ConnectionObject_Initialize(
 
     if (!conn) {
         _mysql_Exception(self);
-        self->open = 0;
         return -1;
     }
 

--- a/MySQLdb/_mysql.c
+++ b/MySQLdb/_mysql.c
@@ -445,9 +445,10 @@ _mysql_ConnectionObject_Initialize(
     }
 
     conn = mysql_init(&(self->connection));
-    if (!conn)
+    if (!conn) {
         PyErr_SetNone(PyExc_MemoryError);
         return -1;
+    }
     Py_BEGIN_ALLOW_THREADS ;
     self->open = 1;
     if (connect_timeout) {

--- a/MySQLdb/_mysql.c
+++ b/MySQLdb/_mysql.c
@@ -444,10 +444,11 @@ _mysql_ConnectionObject_Initialize(
         _stringsuck(cipher, value, ssl);
     }
 
-    Py_BEGIN_ALLOW_THREADS ;
     conn = mysql_init(&(self->connection));
     if (!conn)
-        return PyErr_NoMemory();
+        PyErr_SetNone(PyExc_MemoryError);
+        return -1;
+    Py_BEGIN_ALLOW_THREADS ;
     self->open = 1;
     if (connect_timeout) {
         unsigned int timeout = connect_timeout;


### PR DESCRIPTION
Looking at mysql_real_connect on failure it does not free the memory of the passed in MYSQL* struct. only mysql_close does that.
So we can't set open=0 after we mysql_init or dealloc will not cleanup the memory.

Also if mysql_init returns NULL we are out of memory and shouldn't set open=1, or we could segfault in dealloc if we didn't seg before that.