### PR TITLE
Fixup _mysql.c custom converters binary switch statement to not guess…

### DIFF
--- a/MySQLdb/_mysql.c
+++ b/MySQLdb/_mysql.c
@@ -1132,25 +1132,16 @@ _mysql_field_to_python(
 #ifdef IS_PY3K
     int binary;
     switch (field->type) {
-    case FIELD_TYPE_TINY_BLOB:
-    case FIELD_TYPE_MEDIUM_BLOB:
-    case FIELD_TYPE_LONG_BLOB:
-    case FIELD_TYPE_BLOB:
-    case FIELD_TYPE_VAR_STRING:
-    case FIELD_TYPE_STRING:
-    case FIELD_TYPE_GEOMETRY:
-    case FIELD_TYPE_BIT:
-#ifdef FIELD_TYPE_JSON
-    case FIELD_TYPE_JSON:
-#else
-    case 245: // JSON
-#endif
-        // Call converter with bytes
-        binary = 1;
+    case FIELD_TYPE_DECIMAL:
+    case FIELD_TYPE_NEWDECIMAL:
+    case FIELD_TYPE_TIMESTAMP:
+    case FIELD_TYPE_DATETIME:
+    case FIELD_TYPE_TIME:
+    case FIELD_TYPE_DATE:
+        binary = 0;  // pass str, because these converters expect it
         break;
-    default: // e.g. FIELD_TYPE_DATETIME, etc.
-        // Call converter with unicode string
-        binary = 0;
+    default: // Default to just passing bytes
+        binary = 1;
     }
     return PyObject_CallFunction(converter,
             binary ? "y#" : "s#",


### PR DESCRIPTION
… about encoding of unknown fields for python3

Before *Most* string fields were passed to custom converter functions as "bytes",
everything else was assumed to be valid encoded utf-8 and passed as str.
This could cause issues where some unknown field was not valid utf-8 and
a decode error is triggered where it can't be fixed or avoided by the
end user.

Instead we should short list those fields that we know for sure have to
be str type because the existing converters expect it to be that way.
So all the date conversions, and (NEW)DECIMAL since the python decimal
type will not accept bytes object.

Everything else stays bytes, which is the least suprising and safest
thing to do.