### PR TITLE
Fix error building with --static on debian stretch docker image due to mariadb client name

### DIFF
--- a/setup_posix.py
+++ b/setup_posix.py
@@ -69,7 +69,7 @@ def get_config():
         # properly handle mysql client libraries that are not called libmysqlclient
         client = None
         CLIENT_LIST = ['mysqlclient', 'mysqlclient_r', 'mysqld', 'mariadb',
-                       'perconaserverclient', 'perconaserverclient_r']
+                       'mariadbclient', 'perconaserverclient', 'perconaserverclient_r']
         for c in CLIENT_LIST:
             if c in libraries:
                 client = c


### PR DESCRIPTION
### Scenario

I want to build a statically-linked, binary wheel for the debian stretch-based docker image `python:3.6.8-slim` (so I don't need to install libmysqlclient-dev on all my images)

Example Dockerfile:

```
FROM python:3.6.8-slim as build-mysqlclient

RUN apt update && apt install -y build-essential default-libmysqlclient-dev git

RUN git clone https://github.com/PyMySQL/mysqlclient-python

WORKDIR /mysqlclient-python

RUN python setup.py --static bdist_wheel
```

### Problem

The above Dockerfile gives this error:

```
Step 5/5 : RUN python setup.py --static bdist_wheel
 ---> Running in 1e8aabf66608
Traceback (most recent call last):
  File "setup.py", line 16, in <module>
    metadata, options = get_config()
  File "/mysqlclient-python/setup_posix.py", line 81, in get_config
    raise ValueError("Couldn't identify mysql client library")
ValueError: Couldn't identify mysql client library
The command '/bin/sh -c python setup.py --static bdist_wheel' returned a non-zero code: 1
```

The output from `mysql_config --libs` in the container is:

```
-L/usr/lib/x86_64-linux-gnu  -lmariadbclient -lpthread -lz -lm -ldl
```

### Fix

In `setup_posix.py` the `CLIENT_LIST` includes `mariadb` but not `mariadbclient`. Adding `mariadbclient` to this list allows mysqlclient to build successfully (output shortened):

```
Step 5/5 : RUN python setup.py --static bdist_wheel
 ---> Running in 66163c4e2c6b
running bdist_wheel
running build
running build_py
creating build
creating build/lib.linux-x86_64-3.6
creating build/lib.linux-x86_64-3.6/MySQLdb
[...]
Copying mysqlclient.egg-info to build/bdist.linux-x86_64/wheel/mysqlclient-1.4.2.post1-py3.6.egg-info
running install_scripts
adding license file "LICENSE" (matched pattern "LICEN[CS]E*")
creating build/bdist.linux-x86_64/wheel/mysqlclient-1.4.2.post1.dist-info/WHEEL
creating 'dist/mysqlclient-1.4.2.post1-cp36-cp36m-linux_x86_64.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
[...]
removing build/bdist.linux-x86_64/wheel
Removing intermediate container 66163c4e2c6b
 ---> 7234f193aa69
Successfully built 7234f193aa69
```

Thanks for reading. Let me know if this change is OK, or if it could cause problems for other configurations. 