### PR TITLE
Assume better defaults for windows install (e.g 32bit)

### DIFF
--- a/setup_windows.py
+++ b/setup_windows.py
@@ -1,13 +1,19 @@
-import os, sys
-from distutils.msvccompiler import get_build_version
+import os, platform, sys
+from distutils.msvccompiler import get_build_version, get_build_architecture
 
 
 def get_config():
     from setup_common import get_metadata_and_options, enabled, create_release_file
 
+    interpreter_arch = get_build_architecture()
+    machine_arch = platform.machine()
     metadata, options = get_metadata_and_options()
 
-    connector = options["connector"]
+    connector = options.get('connector')
+    if not connector and machine_arch == 'AMD64' and interpreter_arch == 'Intel':
+        connector = 'C:\Program Files (x86)\MySQL\MySQL Connector C 6.1'
+    elif not connector:
+        connector = 'C:\Program Files\MySQL\MySQL Connector C 6.1'
 
     extra_objects = []
 

--- a/setup_windows.py
+++ b/setup_windows.py
@@ -11,8 +11,8 @@ def get_config():
 
     extra_objects = []
 
-    # client = "mysqlclient"
-    client = "mariadbclient"
+    client = "mysqlclient"
+    # client = "mariadbclient"
 
     vcversion = int(get_build_version())
     if client == "mariadbclient":

--- a/site.cfg
+++ b/site.cfg
@@ -9,4 +9,4 @@ static = False
 
 # http://stackoverflow.com/questions/1972259/mysql-python-install-problem-using-virtualenv-windows-pip
 # Windows connector libs for MySQL. You need a 32-bit connector for your 32-bit Python build.
-connector = C:\Program Files (x86)\MySQL\MySQL Connector C 6.1
+#connector = C:\Program Files (x86)\MySQL\MySQL Connector C 6.1


### PR DESCRIPTION
Fixes a case that was broken for me, 32bit Python on Windows 7 32bit.

I also switched the default client from _mariadbclient_ to _mysqlclient_, I'm not aware of the background of this, but in my opinion assuming  _mysqlclient_ is more foolproof.