### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ An improper ssl configuration may also create issues; see, e.g, `brew info opens
 NOTE: Wheels for Windows may be not released with source package. You should pin version
 in your `requirements.txt` to avoid trying to install newest source package.
 
+NOTE: On Centos pip install fails with gcc error
+
+Error
+``` /usr/bin/ld: cannot find -lmariadb                     
+    collect2: error: ld returned 1 exit status             
+    error: command 'gcc' failed with exit status 1```
+
+change mysql_config 
+
+```
+89:libs="-L$pkglibdir  -lmariadb -lpthread -lz -ldl -lm -lssl -lcrypto"
+90:embedded_libs="-L$pkglibdir  -lmysqld -lpthread -lz -lm -ldl -lssl -lcrypto -lcrypt -llzma -laio -lsystemd"
+```
+to
+
+```
+89:libs="-L$pkglibdir  -lmariadb -lpthread -lz -ldl -lm -lssl -lcrypto"
+90:embedded_libs="-L$pkglibdir  -lmysqld -lpthread -lz -lm -ldl -lssl -lcrypto -lcrypt -llzma -laio -lsystemd"
+91:libs="$embedded_libs"
+```
 
 ### Install from source
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ NOTE: On Centos pip install fails with gcc error
 Error
 ``` /usr/bin/ld: cannot find -lmariadb                     
     collect2: error: ld returned 1 exit status             
-    error: command 'gcc' failed with exit status 1```
+    error: command 'gcc' failed with exit status 1
+```
 
 change mysql_config 
 


### PR DESCRIPTION
solution for problem, not sure if you want to accept it into the README, added similar to the note about MacOS. 

```
(venv) [vmindru@lsv-vm107 mysqlclient]$ pip install mysqlclient --no-cache-dir                                                                                                                                                                
Collecting mysqlclient                                     
  Downloading https://files.pythonhosted.org/packages/4d/38/c5f8bac9c50f3042c8f05615f84206f77f03db79781db841898fde1bb284/mysqlclient-1.4.4.tar.gz (86kB)                                                                                      
     |████████████████████████████████| 92kB 5.6MB/s       
Installing collected packages: mysqlclient                 
  Running setup.py install for mysqlclient ... error       
    ERROR: Command errored out with exit status 1:         
     command: /home/vmindru/proj/amb-web/venv/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-vcz1cygm/mysqlclient/setup.py'"'"'; __file__='"'"'/tmp/pip-install-vcz1cygm/mysqlclient/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-z0q9g9yq/install-record.txt --single-version-externally-managed --compile --install-headers /home/vmindru/proj/amb-web/venv/include/site/python3.6/mysqlclient      
         cwd: /tmp/pip-install-vcz1cygm/mysqlclient/       
    Complete output (30 lines):                            
    running install                                        
    running build                                          
    running build_py                                       
    creating build                                         
    creating build/lib.linux-x86_64-3.6                    
    creating build/lib.linux-x86_64-3.6/MySQLdb            
    copying MySQLdb/__init__.py -> build/lib.linux-x86_64-3.6/MySQLdb                                                  
    copying MySQLdb/_exceptions.py -> build/lib.linux-x86_64-3.6/MySQLdb                                               
    copying MySQLdb/compat.py -> build/lib.linux-x86_64-3.6/MySQLdb                                                    
    copying MySQLdb/connections.py -> build/lib.linux-x86_64-3.6/MySQLdb                                               
    copying MySQLdb/converters.py -> build/lib.linux-x86_64-3.6/MySQLdb                                                
    copying MySQLdb/cursors.py -> build/lib.linux-x86_64-3.6/MySQLdb                                                   
    copying MySQLdb/release.py -> build/lib.linux-x86_64-3.6/MySQLdb                                                   
    copying MySQLdb/times.py -> build/lib.linux-x86_64-3.6/MySQLdb                                                     
    creating build/lib.linux-x86_64-3.6/MySQLdb/constants  
    copying MySQLdb/constants/__init__.py -> build/lib.linux-x86_64-3.6/MySQLdb/constants                              
    copying MySQLdb/constants/CLIENT.py -> build/lib.linux-x86_64-3.6/MySQLdb/constants                                
    copying MySQLdb/constants/CR.py -> build/lib.linux-x86_64-3.6/MySQLdb/constants                                    
    copying MySQLdb/constants/ER.py -> build/lib.linux-x86_64-3.6/MySQLdb/constants                                    
    copying MySQLdb/constants/FIELD_TYPE.py -> build/lib.linux-x86_64-3.6/MySQLdb/constants                            
    copying MySQLdb/constants/FLAG.py -> build/lib.linux-x86_64-3.6/MySQLdb/constants                                  
    running build_ext                                      
    building 'MySQLdb._mysql' extension                    
    creating build/temp.linux-x86_64-3.6                   
    creating build/temp.linux-x86_64-3.6/MySQLdb           
    gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -Dversion_info=(1,4,4,'final',0) -D__version__=1.4.4 -I/usr/include/mysql -I/usr/include/mysql/.. -I/home/vmindru/proj/amb-web/venv/include -I/usr/include/python3.6m -c MySQLdb/_mysql.c -o build/temp.linux-x86_64-3.6/MySQLdb/_mysql.o
    gcc -pthread -shared -Wl,-z,relro -g build/temp.linux-x86_64-3.6/MySQLdb/_mysql.o -L/usr/lib64 -L/usr/lib64 -lmariadb -lpthread -lz -ldl -lm -lssl -lcrypto -lpython3.6m -o build/lib.linux-x86_64-3.6/MySQLdb/_mysql.cpython-36m-x86_64-linux-gnu.so                                                
    /usr/bin/ld: cannot find -lmariadb                     
    collect2: error: ld returned 1 exit status             
    error: command 'gcc' failed with exit status 1         
    ----------------------------------------               
ERROR: Command errored out with exit status 1: /home/vmindru/proj/amb-web/venv/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-vcz1cygm/mysqlclient/setup.py'"'"'; __file__='"'"'/tmp/pip-install-vcz1cygm/mysqlclient/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-z0q9g9yq/install-record.txt --single-version-externally-managed --compile --install-headers /home/vmindru/proj/amb-web/venv/include/site/python3.6/mysqlclient Check the logs for full command output.       
```
this is for 

```
[vmindru@lsv-vm107 mysqlclient]$ cat /etc/redhat-release 
CentOS Linux release 7.7.1908 (Core)
[vmindru@lsv-vm107 mysqlclient]$ pip --version
pip 19.2.3  (python 3.6)
[vmindru@lsv-vm107 mysqlclient]$ 
```

