### PR TITLE
fix PyMemberDef type of two attributes

### DIFF
--- a/MySQLdb/_mysql.c
+++ b/MySQLdb/_mysql.c
@@ -2302,7 +2302,7 @@ static struct PyMemberDef _mysql_ConnectionObject_memberlist[] = {
     },
     {
         "server_capabilities",
-        T_UINT,
+        T_ULONG,
         offsetof(_mysql_ConnectionObject,connection.server_capabilities),
         READONLY,
         "Capabilities of server; consult MySQLdb.constants.CLIENT"
@@ -2316,7 +2316,7 @@ static struct PyMemberDef _mysql_ConnectionObject_memberlist[] = {
     },
     {
         "client_flag",
-        T_UINT,
+        T_ULONG,
         offsetof(_mysql_ConnectionObject,connection.client_flag),
         READONLY,
         "Client flags; refer to MySQLdb.constants.CLIENT"


### PR DESCRIPTION
Two members of the main MYSQL structure are incorrectly defined as unsigned integers rather than unsigned longs in a PyMemberDef declaration. This can result in incorrect values being returned (I found this on SPARC, where client_flag attribute was always zero).

For reference, here is the declaration in the MySQL code (same for 5.5, 5.6, 5.7 and 8.0):
https://github.com/mysql/mysql-server/blob/5.7/include/mysql.h#L287
