### PR TITLE
homebrew migrates mysql-connector-c to mysql-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You may need to install the Python and MySQL development headers and libraries l
 
 * `sudo apt-get install python-dev default-libmysqlclient-dev`  # Debian / Ubuntu
 * `sudo yum install python-devel mysql-devel`  # Red Hat / CentOS
-* `brew install mysql-connector-c`  # macOS (Homebrew)  (Currently, it has bug. See below)
+* `brew install mysql-client`  # macOS (Homebrew)
 
 On Windows, there are binary wheels you can install without MySQLConnector/C or MSVC.
 
@@ -24,33 +24,6 @@ On Windows, there are binary wheels you can install without MySQLConnector/C or 
 `sudo apt-get install python3-dev` # debian / Ubuntu
 
 `sudo yum install python3-devel `  # Red Hat / CentOS
-
-#### **Note about bug of MySQL Connector/C on macOS**
-
-See also: https://bugs.mysql.com/bug.php?id=86971
-
-Versions of MySQL Connector/C may have incorrect default configuration options that cause compilation errors when `mysqlclient-python` is installed.  (As of November 2017, this is known to be true for homebrew's `mysql-connector-c` and [official package](https://dev.mysql.com/downloads/connector/c/))
-
-Modification of `mysql_config` resolves these issues as follows.
-
-Change
-
-```
-# on macOS, on or about line 112:
-# Create options
-libs="-L$pkglibdir"
-libs="$libs -l "
-```
-
-to
-
-```
-# Create options
-libs="-L$pkglibdir"
-libs="$libs -lmysqlclient -lssl -lcrypto"
-```
-
-An improper ssl configuration may also create issues; see, e.g, `brew info openssl` for details on macOS.
 
 ### Install from PyPI
 


### PR DESCRIPTION
they made this change in https://github.com/Homebrew/homebrew-core/pull/46566

I verify that clear install `mysql-client` , version `8.0.18`

the `libs="$libs -lmysqlclient -lssl -lcrypto"` issue has been fixed.

so change the `README.md` to reflect the new change