### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ support in some user forum.  Don't file a issue on the issue tracker.**
 
 You may need to install the Python 3 and MySQL development headers and libraries like so:
 
-* `$ sudo apt-get install python3-dev default-libmysqlclient-dev build-essentials`  # Debian / Ubuntu
+* `$ sudo apt-get install python3-dev default-libmysqlclient-dev build-essential`  # Debian / Ubuntu
 * `% sudo yum install python3-devel mysql-devel`  # Red Hat / CentOS
 
 Then you can install mysqlclient via pip now:


### PR DESCRIPTION
On Debian / Ubuntu, running `$ sudo apt-get install python3-dev default-libmysqlclient-dev build-essentials` will get an error `E: Unable to locate package build-essentials`, because there is no `s` in it, I think.