### PR TITLE
Update the documentation for `Cursor`

### DIFF
--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -674,10 +674,9 @@ CursorDictRowsMixIn
 
 Cursor
     The default cursor class. This class is composed of
-    ``CursorWarningMixIn``, ``CursorStoreResultMixIn``,
-    ``CursorTupleRowsMixIn,`` and ``BaseCursor``, i.e. it raises
-    ``Warning``, uses ``mysql_store_result()``, and returns rows as
-    tuples.
+    ``CursorStoreResultMixIn``, ``CursorTupleRowsMixIn``, and
+    ``BaseCursor``, i.e. uses ``mysql_store_result()`` and returns
+    rows as tuples.
 
 DictCursor
     Like ``Cursor`` except it returns rows as dictionaries.


### PR DESCRIPTION
This change updates the documentation for `Cursor`, since it does not use `CursorWarningMixIn` anymore.