### PR TITLE
Support new installations of MySQL Connector C 6.1

### DIFF
--- a/setup_windows.py
+++ b/setup_windows.py
@@ -12,8 +12,8 @@ def get_config():
 
     extra_objects = []
 
-    # client = "mysqlclient"
-    client = "mariadbclient"
+    client = "mysqlclient"
+    # client = "mariadbclient"
 
     vcversion = int(get_build_version())
     if client == "mariadbclient":

--- a/site.cfg
+++ b/site.cfg
@@ -9,4 +9,4 @@ static = False
 
 # http://stackoverflow.com/questions/1972259/mysql-python-install-problem-using-virtualenv-windows-pip
 # Windows connector libs for MySQL. You need a 32-bit connector for your 32-bit Python build.
-connector = C:\Program Files (x86)\MySQL\MySQL Connector C 6.1
+connector = C:\Program Files\MySQL\MySQL Connector C 6.1


### PR DESCRIPTION
New installations of MySQL Connector C 6.1 default to 'C:\Program Files\.." not 'C:\Program Files (x86)\..'. 
This update also corrects the setup_windows.py client from 'mariadbclient' to 'mysqlclient'