### PR TITLE
GitHub Action with Python 3.9 and MariaDB Connector C 3.1.11

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: windows-latest
     env:
-      CONNECTOR_VERSION: "3.1.9"
+      CONNECTOR_VERSION: "3.1.11"
     steps:
 
       - name: Cache Connector

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -63,6 +63,8 @@ jobs:
         shell: cmd
         working-directory: ../mysqlclient
         run: |
+          py -3.9 -m pip install -U setuptools wheel pip
+          py -3.9 setup.py bdist_wheel
           py -3.8 -m pip install -U setuptools wheel pip
           py -3.8 setup.py bdist_wheel
           py -3.7 -m pip install -U setuptools wheel pip
@@ -81,6 +83,8 @@ jobs:
         working-directory: ../mysqlclient/dist
         run: |
           ls -la
+          py -3.9 -m pip install --no-index --find-links . mysqlclient
+          py -3.9 -c "import MySQLdb; print(MySQLdb.version_info)"
           py -3.8 -m pip install --no-index --find-links . mysqlclient
           py -3.8 -c "import MySQLdb; print(MySQLdb.version_info)"
           py -3.7 -m pip install --no-index --find-links . mysqlclient

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   create:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Updated GitHub Actions to include Python 3.9 build on Windows.
Updated MariaDB Connector C to the latest version (3.1.11), which includes several bugfixes and support for TLS v1.3