### PR TITLE
_mysql: db -> database, passwd -> password

### DIFF
--- a/MySQLdb/_mysql.c
+++ b/MySQLdb/_mysql.c
@@ -414,7 +414,7 @@ _mysql_ConnectionObject_Initialize(
          *db = NULL, *unix_socket = NULL;
     unsigned int port = 0;
     unsigned int client_flag = 0;
-    static char *kwlist[] = { "host", "user", "passwd", "db", "port",
+    static char *kwlist[] = { "host", "user", "password", "database", "port",
                   "unix_socket", "conv",
                   "connect_timeout", "compress",
                   "named_pipe", "init_command",

--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -148,10 +148,10 @@ class Connection(_mysql.connection):
 
         kwargs2 = kwargs.copy()
 
-        if "database" in kwargs2:
-            kwargs2["db"] = kwargs2.pop("database")
-        if "password" in kwargs2:
-            kwargs2["passwd"] = kwargs2.pop("password")
+        if "db" in kwargs2:
+            kwargs2["database"] = kwargs2.pop("db")
+        if "passwd" in kwargs2:
+            kwargs2["password"] = kwargs2.pop("passwd")
 
         if "conv" in kwargs:
             conv = kwargs["conv"]


### PR DESCRIPTION
`_mysql` uses `database` and `password` instead of old `db` and `passwd`.
This rename was done in MySQLdb already.